### PR TITLE
Update solidity contracts

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -34,6 +34,7 @@ QRC721_BASE_URI="ipfs://METADATA_CID/" # Base URI for token metadata (make sure 
 ERC721_NAME="TestQRC721" # Name of collection
 ERC721_SYMBOL="TQ721" # Collection symbol
 ERC721_BASE_URI="ipfs://METADATA_CID/" # Base URI for token metadata (make sure to keep the slash at the end)
+ERC721_MAX_TOKENS=1000 # Maximum number of tokens that can be minted
 
 # QRC20 Arguments
 QRC20_NAME="TestQRC20" # Name of token

--- a/Solidity/arguments/argumentERC721.js
+++ b/Solidity/arguments/argumentERC721.js
@@ -1,3 +1,3 @@
 require('dotenv').config()
 
-module.exports = [process.env.ERC721_NAME, process.env.ERC721_SYMBOL, process.env.ERC721_BASE_URI]
+module.exports = [process.env.ERC721_NAME, process.env.ERC721_SYMBOL, process.env.ERC721_BASE_URI, process.env.ERC721_MAX_TOKENS]

--- a/Solidity/contracts/ERC20.sol
+++ b/Solidity/contracts/ERC20.sol
@@ -14,7 +14,7 @@ contract TestERC20 is ERC20, Ownable {
   * @param initialSupply Initial supply of the token.
   */
   constructor(string memory name, string memory symbol, uint256 initialSupply) ERC20(name, symbol) Ownable(msg.sender) {
-    _mint(msg.sender, initialSupply * 10 ** decimals());
+    _mint(msg.sender, initialSupply);
   }
 
   /**

--- a/Solidity/contracts/ERC721.sol
+++ b/Solidity/contracts/ERC721.sol
@@ -1,14 +1,15 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import "@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/utils/Strings.sol";
 
-contract TestERC721 is ERC721, Ownable {
+contract TestERC721 is ERC721URIStorage, Ownable {
   using Strings for uint256;
   string private baseTokenURI;
   uint256 private mintedTokens;
+  uint256 private maxTokens;
 
   /**
   * @dev Constructor sets msg.sender as contract owner.
@@ -18,9 +19,10 @@ contract TestERC721 is ERC721, Ownable {
   * @param symbol Symbol of the token.
   * @param baseTokenURI_ Base token URI.
   */
-  constructor(string memory name, string memory symbol, string memory baseTokenURI_) ERC721(name, symbol) Ownable(msg.sender) {
+  constructor(string memory name, string memory symbol, string memory baseTokenURI_, uint256 maxTokens_) ERC721(name, symbol) Ownable(msg.sender) {
       baseTokenURI = baseTokenURI_;
-      mintedTokens = 0;
+      mintedTokens = 1;
+      maxTokens = maxTokens_;
   }
 
   /**
@@ -31,15 +33,36 @@ contract TestERC721 is ERC721, Ownable {
   * @param to Address to which tokens are to be minted.
   */
   function mint(address to) public onlyOwner {
-      require(mintedTokens < 1000, "All tokens have been minted");
+      require(mintedTokens < maxTokens, "All tokens have been minted");
       _safeMint(to, mintedTokens);
       mintedTokens++;
   }
 
   /**
-  * @dev Sets the base token URI.
+     * @dev Override required by ERC721URIStorage to return the token URI.
+     * Adds ".json" to the end of the token ID to match the expected format of the tokenURI.
+     * Reverts if token does not exist.
+     * 
+     * @param tokenId The token ID to return the URI for.
+     */
+    function tokenURI(uint256 tokenId) public view virtual override returns (string memory) {
+        require(tokenId <= maxTokens, "Token ID out of range.");
+        require(ownerOf(tokenId) != address(0), "Nonexistent token.");
+        string memory baseURI = _baseURI();
+        return bytes(baseURI).length > 0 ? string(abi.encodePacked(baseURI, tokenId.toString(), ".json")) : "";
+    }
+
+  /**
+  * @dev Returns the base token URI.
   */
   function _baseURI() internal view virtual override returns (string memory) {
       return baseTokenURI;
+  }
+
+  /**
+  * @dev Returns the collection size.
+  */
+  function _maxTokens() public view returns (uint256) {
+      return maxTokens;
   }
 }

--- a/Solidity/package-lock.json
+++ b/Solidity/package-lock.json
@@ -6,11 +6,8 @@
 		"": {
 			"dependencies": {
 				"@openzeppelin/contracts": "^5.0.1",
-				"csv-parse": "^5.5.5",
 				"dotenv": "^16.4.3",
-				"fs": "^0.0.1-security",
 				"hardhat": "^2.19.5",
-				"path": "^0.12.7",
 				"quais": "^0.1.17",
 				"quais-polling": "^1.0.4"
 			},
@@ -26,52 +23,61 @@
 			"peer": true
 		},
 		"node_modules/@ampproject/remapping": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
-			"integrity": "sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+			"integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
 			"dependencies": {
-				"@jridgewell/gen-mapping": "^0.3.0",
-				"@jridgewell/trace-mapping": "^0.3.9"
+				"@jridgewell/gen-mapping": "^0.3.5",
+				"@jridgewell/trace-mapping": "^0.3.24"
 			},
 			"engines": {
 				"node": ">=6.0.0"
 			}
 		},
-		"node_modules/@babel/code-frame": {
-			"version": "7.23.5",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
-			"integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
+		"node_modules/@ampproject/remapping/node_modules/@jridgewell/trace-mapping": {
+			"version": "0.3.25",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+			"integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
 			"dependencies": {
-				"@babel/highlight": "^7.23.4",
-				"chalk": "^2.4.2"
+				"@jridgewell/resolve-uri": "^3.1.0",
+				"@jridgewell/sourcemap-codec": "^1.4.14"
+			}
+		},
+		"node_modules/@babel/code-frame": {
+			"version": "7.24.2",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.2.tgz",
+			"integrity": "sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==",
+			"dependencies": {
+				"@babel/highlight": "^7.24.2",
+				"picocolors": "^1.0.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/compat-data": {
-			"version": "7.23.5",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.5.tgz",
-			"integrity": "sha512-uU27kfDRlhfKl+w1U6vp16IuvSLtjAxdArVXPa9BvLkrr7CYIsxH5adpHObeAGY/41+syctUWOZ140a2Rvkgjw==",
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.24.1.tgz",
+			"integrity": "sha512-Pc65opHDliVpRHuKfzI+gSA4zcgr65O4cl64fFJIWEEh8JoHIHh0Oez1Eo8Arz8zq/JhgKodQaxEwUPRtZylVA==",
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.23.9",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.9.tgz",
-			"integrity": "sha512-5q0175NOjddqpvvzU+kDiSOAk4PfdO6FvwCWoQ6RO7rTzEe8vlo+4HVfcnAREhD4npMs0e9uZypjTwzZPCf/cw==",
+			"version": "7.24.3",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.3.tgz",
+			"integrity": "sha512-5FcvN1JHw2sHJChotgx8Ek0lyuh4kCKelgMTTqhYJJtloNvUfpAFMeNQUtdlIaktwrSV9LtCdqwk48wL2wBacQ==",
 			"dependencies": {
 				"@ampproject/remapping": "^2.2.0",
-				"@babel/code-frame": "^7.23.5",
-				"@babel/generator": "^7.23.6",
+				"@babel/code-frame": "^7.24.2",
+				"@babel/generator": "^7.24.1",
 				"@babel/helper-compilation-targets": "^7.23.6",
 				"@babel/helper-module-transforms": "^7.23.3",
-				"@babel/helpers": "^7.23.9",
-				"@babel/parser": "^7.23.9",
-				"@babel/template": "^7.23.9",
-				"@babel/traverse": "^7.23.9",
-				"@babel/types": "^7.23.9",
+				"@babel/helpers": "^7.24.1",
+				"@babel/parser": "^7.24.1",
+				"@babel/template": "^7.24.0",
+				"@babel/traverse": "^7.24.1",
+				"@babel/types": "^7.24.0",
 				"convert-source-map": "^2.0.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
@@ -87,13 +93,13 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.23.6",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.6.tgz",
-			"integrity": "sha512-qrSfCYxYQB5owCmGLbl8XRpX1ytXlpueOb0N0UmQwA073KZxejgQTzAmJezxvpwQD9uGtK2shHdi55QT+MbjIw==",
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.1.tgz",
+			"integrity": "sha512-DfCRfZsBcrPEHUfuBMgbJ1Ut01Y/itOs+hY2nFLgqsqXd52/iSiVq5TITtUasIUgm+IIKdY2/1I7auiQOEeC9A==",
 			"dependencies": {
-				"@babel/types": "^7.23.6",
-				"@jridgewell/gen-mapping": "^0.3.2",
-				"@jridgewell/trace-mapping": "^0.3.17",
+				"@babel/types": "^7.24.0",
+				"@jridgewell/gen-mapping": "^0.3.5",
+				"@jridgewell/trace-mapping": "^0.3.25",
 				"jsesc": "^2.5.1"
 			},
 			"engines": {
@@ -101,9 +107,9 @@
 			}
 		},
 		"node_modules/@babel/generator/node_modules/@jridgewell/trace-mapping": {
-			"version": "0.3.22",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.22.tgz",
-			"integrity": "sha512-Wf963MzWtA2sjrNt+g18IAln9lKnlRp+K2eH4jjIoF1wYeq3aMREpG09xhlhdzS0EjwU7qmUJYangWa+151vZw==",
+			"version": "0.3.25",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+			"integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.1.0",
 				"@jridgewell/sourcemap-codec": "^1.4.14"
@@ -156,11 +162,11 @@
 			}
 		},
 		"node_modules/@babel/helper-module-imports": {
-			"version": "7.22.15",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz",
-			"integrity": "sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==",
+			"version": "7.24.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.3.tgz",
+			"integrity": "sha512-viKb0F9f2s0BCS22QSF308z/+1YWKV/76mwt61NBzS5izMzDPwdq1pTrzf+Li3npBWX9KdQbkeCt1jSAM7lZqg==",
 			"dependencies": {
-				"@babel/types": "^7.22.15"
+				"@babel/types": "^7.24.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -207,9 +213,9 @@
 			}
 		},
 		"node_modules/@babel/helper-string-parser": {
-			"version": "7.23.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.23.4.tgz",
-			"integrity": "sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==",
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.1.tgz",
+			"integrity": "sha512-2ofRCjnnA9y+wk8b9IAREroeUP02KHp431N2mhKniy2yKIDKpbrHv9eXwm8cBeWQYcJmzv5qKCu65P47eCF7CQ==",
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -231,35 +237,36 @@
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.23.9",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.9.tgz",
-			"integrity": "sha512-87ICKgU5t5SzOT7sBMfCOZQ2rHjRU+Pcb9BoILMYz600W6DkVRLFBPwQ18gwUVvggqXivaUakpnxWQGbpywbBQ==",
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.1.tgz",
+			"integrity": "sha512-BpU09QqEe6ZCHuIHFphEFgvNSrubve1FtyMton26ekZ85gRGi6LrTF7zArARp2YvyFxloeiRmtSCq5sjh1WqIg==",
 			"dependencies": {
-				"@babel/template": "^7.23.9",
-				"@babel/traverse": "^7.23.9",
-				"@babel/types": "^7.23.9"
+				"@babel/template": "^7.24.0",
+				"@babel/traverse": "^7.24.1",
+				"@babel/types": "^7.24.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/highlight": {
-			"version": "7.23.4",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
-			"integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
+			"version": "7.24.2",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.2.tgz",
+			"integrity": "sha512-Yac1ao4flkTxTteCDZLEvdxg2fZfz1v8M4QpaGypq/WPDqg3ijHYbDfs+LG5hvzSoqaSZ9/Z9lKSP3CjZjv+pA==",
 			"dependencies": {
 				"@babel/helper-validator-identifier": "^7.22.20",
 				"chalk": "^2.4.2",
-				"js-tokens": "^4.0.0"
+				"js-tokens": "^4.0.0",
+				"picocolors": "^1.0.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.23.9",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.9.tgz",
-			"integrity": "sha512-9tcKgqKbs3xGJ+NtKF2ndOBBLVwPjl1SHxPQkd36r3Dlirw3xWUeGaTbqr7uGZcTaxkVNwc+03SVP7aCdWrTlA==",
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.1.tgz",
+			"integrity": "sha512-Zo9c7N3xdOIQrNip7Lc9wvRPzlRtovHVE4lkz8WEDr7uYh/GMQhSiIgFxGIArRHYdJE5kxtZjAf8rT0xhdLCzg==",
 			"bin": {
 				"parser": "bin/babel-parser.js"
 			},
@@ -268,39 +275,39 @@
 			}
 		},
 		"node_modules/@babel/standalone": {
-			"version": "7.23.10",
-			"resolved": "https://registry.npmjs.org/@babel/standalone/-/standalone-7.23.10.tgz",
-			"integrity": "sha512-xqWviI/pt1Zb/d+6ilWa5IDL2mkDzsBnlHbreqnfyP3/QB/ofQ1bNVcHj8YQX154Rf/xZKR6y0s1ydVF3nAS8g==",
+			"version": "7.24.3",
+			"resolved": "https://registry.npmjs.org/@babel/standalone/-/standalone-7.24.3.tgz",
+			"integrity": "sha512-PbObiI21Z/1DoJLr6DKsdmyp7uUIuw6zv5zIMorH98rOBE/TehkjK7xqXiwJmbCqi7deVbIksDerZ9Ds9hRLGw==",
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/template": {
-			"version": "7.23.9",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.23.9.tgz",
-			"integrity": "sha512-+xrD2BWLpvHKNmX2QbpdpsBaWnRxahMwJjO+KZk2JOElj5nSmKezyS1B4u+QbHMTX69t4ukm6hh9lsYQ7GHCKA==",
+			"version": "7.24.0",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.0.tgz",
+			"integrity": "sha512-Bkf2q8lMB0AFpX0NFEqSbx1OkTHf0f+0j82mkw+ZpzBnkk7e9Ql0891vlfgi+kHwOk8tQjiQHpqh4LaSa0fKEA==",
 			"dependencies": {
 				"@babel/code-frame": "^7.23.5",
-				"@babel/parser": "^7.23.9",
-				"@babel/types": "^7.23.9"
+				"@babel/parser": "^7.24.0",
+				"@babel/types": "^7.24.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.23.9",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.9.tgz",
-			"integrity": "sha512-I/4UJ9vs90OkBtY6iiiTORVMyIhJ4kAVmsKo9KFc8UOxMeUfi2hvtIBsET5u9GizXE6/GFSuKCTNfgCswuEjRg==",
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.1.tgz",
+			"integrity": "sha512-xuU6o9m68KeqZbQuDt2TcKSxUw/mrsvavlEqQ1leZ/B+C9tk6E4sRWy97WaXgvq5E+nU3cXMxv3WKOCanVMCmQ==",
 			"dependencies": {
-				"@babel/code-frame": "^7.23.5",
-				"@babel/generator": "^7.23.6",
+				"@babel/code-frame": "^7.24.1",
+				"@babel/generator": "^7.24.1",
 				"@babel/helper-environment-visitor": "^7.22.20",
 				"@babel/helper-function-name": "^7.23.0",
 				"@babel/helper-hoist-variables": "^7.22.5",
 				"@babel/helper-split-export-declaration": "^7.22.6",
-				"@babel/parser": "^7.23.9",
-				"@babel/types": "^7.23.9",
+				"@babel/parser": "^7.24.1",
+				"@babel/types": "^7.24.0",
 				"debug": "^4.3.1",
 				"globals": "^11.1.0"
 			},
@@ -309,9 +316,9 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.23.9",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.9.tgz",
-			"integrity": "sha512-dQjSq/7HaSjRM43FFGnv5keM2HsxpmyV1PfaSVm0nzzjwwTmjOe6J4bC8e3+pTEIgHaHj+1ZlLThRJ2auc/w1Q==",
+			"version": "7.24.0",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.0.tgz",
+			"integrity": "sha512-+j7a5c253RfKh8iABBhywc8NSfP5LURe7Uh4qpsh6jc+aLJguvmIUBdjSdEMQv2bENrCR5MfRdjGo7vzS/ob7w==",
 			"dependencies": {
 				"@babel/helper-string-parser": "^7.23.4",
 				"@babel/helper-validator-identifier": "^7.22.20",
@@ -319,29 +326,6 @@
 			},
 			"engines": {
 				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@chainsafe/as-sha256": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/@chainsafe/as-sha256/-/as-sha256-0.3.1.tgz",
-			"integrity": "sha512-hldFFYuf49ed7DAakWVXSJODuq3pzJEguD8tQ7h+sGkM18vja+OFoJI9krnGmgzyuZC2ETX0NOIcCTy31v2Mtg=="
-		},
-		"node_modules/@chainsafe/persistent-merkle-tree": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/@chainsafe/persistent-merkle-tree/-/persistent-merkle-tree-0.4.2.tgz",
-			"integrity": "sha512-lLO3ihKPngXLTus/L7WHKaw9PnNJWizlOF1H9NNzHP6Xvh82vzg9F2bzkXhYIFshMZ2gTCEz8tq6STe7r5NDfQ==",
-			"dependencies": {
-				"@chainsafe/as-sha256": "^0.3.1"
-			}
-		},
-		"node_modules/@chainsafe/ssz": {
-			"version": "0.9.4",
-			"resolved": "https://registry.npmjs.org/@chainsafe/ssz/-/ssz-0.9.4.tgz",
-			"integrity": "sha512-77Qtg2N1ayqs4Bg/wvnWfg5Bta7iy7IRh8XqXh7oNMeP2HBbBwx8m6yTpA8p0EHItWPEBkgZd5S5/LSlp3GXuQ==",
-			"dependencies": {
-				"@chainsafe/as-sha256": "^0.3.1",
-				"@chainsafe/persistent-merkle-tree": "^0.4.2",
-				"case": "^1.6.3"
 			}
 		},
 		"node_modules/@cspotcode/source-map-support": {
@@ -885,6 +869,7 @@
 			"version": "5.7.0",
 			"resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.7.0.tgz",
 			"integrity": "sha512-ywlh43GwZLv2Voc2gQVTKBoVQ1mti3d8HK5aMxsfu/nRDnMmNqaSJ3r3n85HBByT8OpoY96SXM1FogC533T4zw==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "individual",
@@ -895,6 +880,7 @@
 					"url": "https://www.buymeacoffee.com/ricmoo"
 				}
 			],
+			"peer": true,
 			"dependencies": {
 				"@ethersproject/bytes": "^5.7.0",
 				"@ethersproject/properties": "^5.7.0"
@@ -960,6 +946,7 @@
 			"version": "5.7.0",
 			"resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.7.0.tgz",
 			"integrity": "sha512-5GJbzEU3X+d33CdfPhcyS+z8MzsTrBGk/sc+G+59+tPa9yFkl6HQ9D6L0QMgNTA9q8dT0XKxxkyp883XsQvbbg==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "individual",
@@ -970,6 +957,7 @@
 					"url": "https://www.buymeacoffee.com/ricmoo"
 				}
 			],
+			"peer": true,
 			"dependencies": {
 				"@ethersproject/abi": "^5.7.0",
 				"@ethersproject/abstract-provider": "^5.7.0",
@@ -1013,6 +1001,7 @@
 			"version": "5.7.0",
 			"resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.7.0.tgz",
 			"integrity": "sha512-OmyYo9EENBPPf4ERhR7oj6uAtUAhYGqOnIS+jE5pTXvdKBS99ikzq1E7Iv0ZQZ5V36Lqx1qZLeak0Ra16qpeOg==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "individual",
@@ -1023,6 +1012,7 @@
 					"url": "https://www.buymeacoffee.com/ricmoo"
 				}
 			],
+			"peer": true,
 			"dependencies": {
 				"@ethersproject/abstract-signer": "^5.7.0",
 				"@ethersproject/basex": "^5.7.0",
@@ -1042,6 +1032,7 @@
 			"version": "5.7.0",
 			"resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.7.0.tgz",
 			"integrity": "sha512-8oee5Xgu6+RKgJTkvEMl2wDgSPSAQ9MB/3JYjFV9jlKvcYHUXZC+cQp0njgmxdHkYWn8s6/IqIZYm0YWCjO/0g==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "individual",
@@ -1052,6 +1043,7 @@
 					"url": "https://www.buymeacoffee.com/ricmoo"
 				}
 			],
+			"peer": true,
 			"dependencies": {
 				"@ethersproject/abstract-signer": "^5.7.0",
 				"@ethersproject/address": "^5.7.0",
@@ -1071,7 +1063,9 @@
 		"node_modules/@ethersproject/json-wallets/node_modules/aes-js": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
-			"integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw=="
+			"integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw==",
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/@ethersproject/keccak256": {
 			"version": "5.7.0",
@@ -1129,6 +1123,7 @@
 			"version": "5.7.0",
 			"resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.7.0.tgz",
 			"integrity": "sha512-oR/dBRZR6GTyaofd86DehG72hY6NpAjhabkhxgr3X2FpJtJuodEl2auADWBZfhDHgVCbu3/H/Ocq2uC6dpNjjw==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "individual",
@@ -1139,6 +1134,7 @@
 					"url": "https://www.buymeacoffee.com/ricmoo"
 				}
 			],
+			"peer": true,
 			"dependencies": {
 				"@ethersproject/bytes": "^5.7.0",
 				"@ethersproject/sha2": "^5.7.0"
@@ -1166,6 +1162,7 @@
 			"version": "5.7.2",
 			"resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.7.2.tgz",
 			"integrity": "sha512-g34EWZ1WWAVgr4aptGlVBF8mhl3VWjv+8hoAnzStu8Ah22VHBsuGzP17eb6xDVRzw895G4W7vvx60lFFur/1Rg==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "individual",
@@ -1176,6 +1173,7 @@
 					"url": "https://www.buymeacoffee.com/ricmoo"
 				}
 			],
+			"peer": true,
 			"dependencies": {
 				"@ethersproject/abstract-provider": "^5.7.0",
 				"@ethersproject/abstract-signer": "^5.7.0",
@@ -1203,6 +1201,8 @@
 			"version": "7.4.6",
 			"resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
 			"integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=8.3.0"
 			},
@@ -1223,6 +1223,7 @@
 			"version": "5.7.0",
 			"resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.7.0.tgz",
 			"integrity": "sha512-19WjScqRA8IIeWclFme75VMXSBvi4e6InrUNuaR4s5pTF2qNhcGdCUwdxUVGtDDqC00sDLCO93jPQoDUH4HVmQ==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "individual",
@@ -1233,6 +1234,7 @@
 					"url": "https://www.buymeacoffee.com/ricmoo"
 				}
 			],
+			"peer": true,
 			"dependencies": {
 				"@ethersproject/bytes": "^5.7.0",
 				"@ethersproject/logger": "^5.7.0"
@@ -1261,6 +1263,7 @@
 			"version": "5.7.0",
 			"resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.7.0.tgz",
 			"integrity": "sha512-gKlH42riwb3KYp0reLsFTokByAKoJdgFCwI+CCiX/k+Jm2mbNs6oOaCjYQSlI1+XBVejwH2KrmCbMAT/GnRDQw==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "individual",
@@ -1271,6 +1274,7 @@
 					"url": "https://www.buymeacoffee.com/ricmoo"
 				}
 			],
+			"peer": true,
 			"dependencies": {
 				"@ethersproject/bytes": "^5.7.0",
 				"@ethersproject/logger": "^5.7.0",
@@ -1304,6 +1308,7 @@
 			"version": "5.7.0",
 			"resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.7.0.tgz",
 			"integrity": "sha512-HmabMd2Dt/raavyaGukF4XxizWKhKQ24DoLtdNbBmNKUOPqwjsKQSdV9GQtj9CBEea9DlzETlVER1gYeXXBGaA==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "individual",
@@ -1314,6 +1319,7 @@
 					"url": "https://www.buymeacoffee.com/ricmoo"
 				}
 			],
+			"peer": true,
 			"dependencies": {
 				"@ethersproject/bignumber": "^5.7.0",
 				"@ethersproject/bytes": "^5.7.0",
@@ -1373,6 +1379,7 @@
 			"version": "5.7.0",
 			"resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.7.0.tgz",
 			"integrity": "sha512-pD3xLMy3SJu9kG5xDGI7+xhTEmGXlEqXU4OfNapmfnxLVY4EMSSRp7j1k7eezutBPH7RBN/7QPnwR7hzNlEFeg==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "individual",
@@ -1383,6 +1390,7 @@
 					"url": "https://www.buymeacoffee.com/ricmoo"
 				}
 			],
+			"peer": true,
 			"dependencies": {
 				"@ethersproject/bignumber": "^5.7.0",
 				"@ethersproject/constants": "^5.7.0",
@@ -1393,6 +1401,7 @@
 			"version": "5.7.0",
 			"resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.7.0.tgz",
 			"integrity": "sha512-MhmXlJXEJFBFVKrDLB4ZdDzxcBxQ3rLyCkhNqVu3CDYvR97E+8r01UgrI+TI99Le+aYm/in/0vp86guJuM7FCA==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "individual",
@@ -1403,6 +1412,7 @@
 					"url": "https://www.buymeacoffee.com/ricmoo"
 				}
 			],
+			"peer": true,
 			"dependencies": {
 				"@ethersproject/abstract-provider": "^5.7.0",
 				"@ethersproject/abstract-signer": "^5.7.0",
@@ -1447,6 +1457,7 @@
 			"version": "5.7.0",
 			"resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.7.0.tgz",
 			"integrity": "sha512-S2TFNJNfHWVHNE6cNDjbVlZ6MgE17MIxMbMg2zv3wn+3XSJGosL1m9ZVv3GXCf/2ymSsQ+hRI5IzoMJTG6aoVA==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "individual",
@@ -1457,6 +1468,7 @@
 					"url": "https://www.buymeacoffee.com/ricmoo"
 				}
 			],
+			"peer": true,
 			"dependencies": {
 				"@ethersproject/bytes": "^5.7.0",
 				"@ethersproject/hash": "^5.7.0",
@@ -1466,38 +1478,47 @@
 			}
 		},
 		"node_modules/@fastify/busboy": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.0.tgz",
-			"integrity": "sha512-+KpH+QxZU7O4675t3mnkQKcZZg56u+K/Ct2K+N2AZYNVK8kyeo/bI18tI8aPm3tvNNRyTWfj6s5tnGNlcbQRsA==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+			"integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
 			"engines": {
 				"node": ">=14"
 			}
 		},
 		"node_modules/@jridgewell/gen-mapping": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
-			"integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+			"integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
 			"dependencies": {
-				"@jridgewell/set-array": "^1.0.1",
+				"@jridgewell/set-array": "^1.2.1",
 				"@jridgewell/sourcemap-codec": "^1.4.10",
-				"@jridgewell/trace-mapping": "^0.3.9"
+				"@jridgewell/trace-mapping": "^0.3.24"
 			},
 			"engines": {
 				"node": ">=6.0.0"
 			}
 		},
+		"node_modules/@jridgewell/gen-mapping/node_modules/@jridgewell/trace-mapping": {
+			"version": "0.3.25",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+			"integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+			"dependencies": {
+				"@jridgewell/resolve-uri": "^3.1.0",
+				"@jridgewell/sourcemap-codec": "^1.4.14"
+			}
+		},
 		"node_modules/@jridgewell/resolve-uri": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
-			"integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+			"integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
 			"engines": {
 				"node": ">=6.0.0"
 			}
 		},
 		"node_modules/@jridgewell/set-array": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-			"integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+			"integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
 			"engines": {
 				"node": ">=6.0.0"
 			}
@@ -1511,6 +1532,8 @@
 			"version": "0.3.9",
 			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
 			"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+			"devOptional": true,
+			"peer": true,
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.0.3",
 				"@jridgewell/sourcemap-codec": "^1.4.10"
@@ -1627,295 +1650,225 @@
 				"node": ">= 8"
 			}
 		},
-		"node_modules/@nomicfoundation/ethereumjs-block": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-block/-/ethereumjs-block-5.0.2.tgz",
-			"integrity": "sha512-hSe6CuHI4SsSiWWjHDIzWhSiAVpzMUcDRpWYzN0T9l8/Rz7xNn3elwVOJ/tAyS0LqL6vitUD78Uk7lQDXZun7Q==",
-			"dependencies": {
-				"@nomicfoundation/ethereumjs-common": "4.0.2",
-				"@nomicfoundation/ethereumjs-rlp": "5.0.2",
-				"@nomicfoundation/ethereumjs-trie": "6.0.2",
-				"@nomicfoundation/ethereumjs-tx": "5.0.2",
-				"@nomicfoundation/ethereumjs-util": "9.0.2",
-				"ethereum-cryptography": "0.1.3",
-				"ethers": "^5.7.1"
-			},
+		"node_modules/@nomicfoundation/edr": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/@nomicfoundation/edr/-/edr-0.3.3.tgz",
+			"integrity": "sha512-zP+e+3B1nEUx6bW5BPnIzCQbkhmYfdMBJdiVggTqqTfAA82sOkdOG7wsOMcz5qF3fYfx/irNRM1kgc9HVFIbpQ==",
 			"engines": {
-				"node": ">=14"
+				"node": ">= 18"
+			},
+			"optionalDependencies": {
+				"@nomicfoundation/edr-darwin-arm64": "0.3.3",
+				"@nomicfoundation/edr-darwin-x64": "0.3.3",
+				"@nomicfoundation/edr-linux-arm64-gnu": "0.3.3",
+				"@nomicfoundation/edr-linux-arm64-musl": "0.3.3",
+				"@nomicfoundation/edr-linux-x64-gnu": "0.3.3",
+				"@nomicfoundation/edr-linux-x64-musl": "0.3.3",
+				"@nomicfoundation/edr-win32-arm64-msvc": "0.3.3",
+				"@nomicfoundation/edr-win32-ia32-msvc": "0.3.3",
+				"@nomicfoundation/edr-win32-x64-msvc": "0.3.3"
 			}
 		},
-		"node_modules/@nomicfoundation/ethereumjs-block/node_modules/ethers": {
-			"version": "5.7.2",
-			"resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
-			"integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
+		"node_modules/@nomicfoundation/edr-darwin-arm64": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-arm64/-/edr-darwin-arm64-0.3.3.tgz",
+			"integrity": "sha512-E9VGsUD+1Ga4mn/5ooHsMi8JEfhZbKP6CXN/BhJ8kXbIC10NqTD1RuhCKGRtYq4vqH/3Nfq25Xg8E8RWOF4KBQ==",
+			"cpu": [
+				"arm64"
 			],
-			"dependencies": {
-				"@ethersproject/abi": "5.7.0",
-				"@ethersproject/abstract-provider": "5.7.0",
-				"@ethersproject/abstract-signer": "5.7.0",
-				"@ethersproject/address": "5.7.0",
-				"@ethersproject/base64": "5.7.0",
-				"@ethersproject/basex": "5.7.0",
-				"@ethersproject/bignumber": "5.7.0",
-				"@ethersproject/bytes": "5.7.0",
-				"@ethersproject/constants": "5.7.0",
-				"@ethersproject/contracts": "5.7.0",
-				"@ethersproject/hash": "5.7.0",
-				"@ethersproject/hdnode": "5.7.0",
-				"@ethersproject/json-wallets": "5.7.0",
-				"@ethersproject/keccak256": "5.7.0",
-				"@ethersproject/logger": "5.7.0",
-				"@ethersproject/networks": "5.7.1",
-				"@ethersproject/pbkdf2": "5.7.0",
-				"@ethersproject/properties": "5.7.0",
-				"@ethersproject/providers": "5.7.2",
-				"@ethersproject/random": "5.7.0",
-				"@ethersproject/rlp": "5.7.0",
-				"@ethersproject/sha2": "5.7.0",
-				"@ethersproject/signing-key": "5.7.0",
-				"@ethersproject/solidity": "5.7.0",
-				"@ethersproject/strings": "5.7.0",
-				"@ethersproject/transactions": "5.7.0",
-				"@ethersproject/units": "5.7.0",
-				"@ethersproject/wallet": "5.7.0",
-				"@ethersproject/web": "5.7.1",
-				"@ethersproject/wordlists": "5.7.0"
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 18"
 			}
 		},
-		"node_modules/@nomicfoundation/ethereumjs-blockchain": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-blockchain/-/ethereumjs-blockchain-7.0.2.tgz",
-			"integrity": "sha512-8UUsSXJs+MFfIIAKdh3cG16iNmWzWC/91P40sazNvrqhhdR/RtGDlFk2iFTGbBAZPs2+klZVzhRX8m2wvuvz3w==",
-			"dependencies": {
-				"@nomicfoundation/ethereumjs-block": "5.0.2",
-				"@nomicfoundation/ethereumjs-common": "4.0.2",
-				"@nomicfoundation/ethereumjs-ethash": "3.0.2",
-				"@nomicfoundation/ethereumjs-rlp": "5.0.2",
-				"@nomicfoundation/ethereumjs-trie": "6.0.2",
-				"@nomicfoundation/ethereumjs-tx": "5.0.2",
-				"@nomicfoundation/ethereumjs-util": "9.0.2",
-				"abstract-level": "^1.0.3",
-				"debug": "^4.3.3",
-				"ethereum-cryptography": "0.1.3",
-				"level": "^8.0.0",
-				"lru-cache": "^5.1.1",
-				"memory-level": "^1.0.0"
-			},
+		"node_modules/@nomicfoundation/edr-darwin-x64": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-x64/-/edr-darwin-x64-0.3.3.tgz",
+			"integrity": "sha512-vkZXZ1ydPg+Ijb2iyqENA+KCkxGTCUWG5itCSliiA0Li2YE7ujDMGhheEpFp1WVlZadviz0bfk1rZXbCqlirpg==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"darwin"
+			],
 			"engines": {
-				"node": ">=14"
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@nomicfoundation/edr-linux-arm64-gnu": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-gnu/-/edr-linux-arm64-gnu-0.3.3.tgz",
+			"integrity": "sha512-gdIg0Yj1qqS9wVuywc5B/+DqKylfUGB6/CQn/shMqwAfsAVAVpchkhy66PR+REEx7fh/GkNctxLlENXPeLzDiA==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@nomicfoundation/edr-linux-arm64-musl": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-musl/-/edr-linux-arm64-musl-0.3.3.tgz",
+			"integrity": "sha512-AXZ08MFvhNeBZbOBNmz1SJ/DMrMOE2mHEJtaNnsctlxIunjxfrWww4q+WXB34jbr9iaVYYlPsaWe5sueuw6s3Q==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@nomicfoundation/edr-linux-x64-gnu": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-gnu/-/edr-linux-x64-gnu-0.3.3.tgz",
+			"integrity": "sha512-xElOs1U+E6lBLtv1mnJ+E8nr2MxZgKiLo8bZAgBboy9odYtmkDVwhMjtsFKSuZbGxFtsSyGRT4cXw3JAbtUDeA==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@nomicfoundation/edr-linux-x64-musl": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-musl/-/edr-linux-x64-musl-0.3.3.tgz",
+			"integrity": "sha512-2Fe6gwm1RAGQ/PfMYiaSba2OrFp8zzYWh+am9lYObOFjV9D+A1zhIzfy0UC74glPks5eV8eY4pBPrVR042m2Nw==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@nomicfoundation/edr-win32-arm64-msvc": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/@nomicfoundation/edr-win32-arm64-msvc/-/edr-win32-arm64-msvc-0.3.3.tgz",
+			"integrity": "sha512-8NHyxIsFrl0ufSQ/ErqF2lKIa/gz1gaaa1a2vKkDEqvqCUcPhBTYhA5NHgTPhLETFTnCFr0z+YbctFCyjh4qrA==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@nomicfoundation/edr-win32-ia32-msvc": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/@nomicfoundation/edr-win32-ia32-msvc/-/edr-win32-ia32-msvc-0.3.3.tgz",
+			"integrity": "sha512-0F6hM0kGia4dQVb/kauho9JcP1ozWisY2/She+ISR5ceuhzmAwQJluM0g+0TYDME0LtxBxiMPq/yPiZMQeq31w==",
+			"cpu": [
+				"ia32"
+			],
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@nomicfoundation/edr-win32-x64-msvc": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/@nomicfoundation/edr-win32-x64-msvc/-/edr-win32-x64-msvc-0.3.3.tgz",
+			"integrity": "sha512-d75q1uaMb6z9i+GQZoblbOfFBvlBnWc+5rB13UWRkCOJSnoYwyFWhGJx5GeM59gC7aIblc5VD9qOAhHuvM9N+w==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 18"
 			}
 		},
 		"node_modules/@nomicfoundation/ethereumjs-common": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-common/-/ethereumjs-common-4.0.2.tgz",
-			"integrity": "sha512-I2WGP3HMGsOoycSdOTSqIaES0ughQTueOsddJ36aYVpI3SN8YSusgRFLwzDJwRFVIYDKx/iJz0sQ5kBHVgdDwg==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-common/-/ethereumjs-common-4.0.4.tgz",
+			"integrity": "sha512-9Rgb658lcWsjiicr5GzNCjI1llow/7r0k50dLL95OJ+6iZJcVbi15r3Y0xh2cIO+zgX0WIHcbzIu6FeQf9KPrg==",
 			"dependencies": {
-				"@nomicfoundation/ethereumjs-util": "9.0.2",
-				"crc-32": "^1.2.0"
-			}
-		},
-		"node_modules/@nomicfoundation/ethereumjs-ethash": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-ethash/-/ethereumjs-ethash-3.0.2.tgz",
-			"integrity": "sha512-8PfoOQCcIcO9Pylq0Buijuq/O73tmMVURK0OqdjhwqcGHYC2PwhbajDh7GZ55ekB0Px197ajK3PQhpKoiI/UPg==",
-			"dependencies": {
-				"@nomicfoundation/ethereumjs-block": "5.0.2",
-				"@nomicfoundation/ethereumjs-rlp": "5.0.2",
-				"@nomicfoundation/ethereumjs-util": "9.0.2",
-				"abstract-level": "^1.0.3",
-				"bigint-crypto-utils": "^3.0.23",
-				"ethereum-cryptography": "0.1.3"
-			},
-			"engines": {
-				"node": ">=14"
-			}
-		},
-		"node_modules/@nomicfoundation/ethereumjs-evm": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-evm/-/ethereumjs-evm-2.0.2.tgz",
-			"integrity": "sha512-rBLcUaUfANJxyOx9HIdMX6uXGin6lANCulIm/pjMgRqfiCRMZie3WKYxTSd8ZE/d+qT+zTedBF4+VHTdTSePmQ==",
-			"dependencies": {
-				"@ethersproject/providers": "^5.7.1",
-				"@nomicfoundation/ethereumjs-common": "4.0.2",
-				"@nomicfoundation/ethereumjs-tx": "5.0.2",
-				"@nomicfoundation/ethereumjs-util": "9.0.2",
-				"debug": "^4.3.3",
-				"ethereum-cryptography": "0.1.3",
-				"mcl-wasm": "^0.7.1",
-				"rustbn.js": "~0.2.0"
-			},
-			"engines": {
-				"node": ">=14"
+				"@nomicfoundation/ethereumjs-util": "9.0.4"
 			}
 		},
 		"node_modules/@nomicfoundation/ethereumjs-rlp": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-rlp/-/ethereumjs-rlp-5.0.2.tgz",
-			"integrity": "sha512-QwmemBc+MMsHJ1P1QvPl8R8p2aPvvVcKBbvHnQOKBpBztEo0omN0eaob6FeZS/e3y9NSe+mfu3nNFBHszqkjTA==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-rlp/-/ethereumjs-rlp-5.0.4.tgz",
+			"integrity": "sha512-8H1S3s8F6QueOc/X92SdrA4RDenpiAEqMg5vJH99kcQaCy/a3Q6fgseo75mgWlbanGJXSlAPtnCeG9jvfTYXlw==",
 			"bin": {
-				"rlp": "bin/rlp"
+				"rlp": "bin/rlp.cjs"
 			},
 			"engines": {
-				"node": ">=14"
-			}
-		},
-		"node_modules/@nomicfoundation/ethereumjs-statemanager": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-statemanager/-/ethereumjs-statemanager-2.0.2.tgz",
-			"integrity": "sha512-dlKy5dIXLuDubx8Z74sipciZnJTRSV/uHG48RSijhgm1V7eXYFC567xgKtsKiVZB1ViTP9iFL4B6Je0xD6X2OA==",
-			"dependencies": {
-				"@nomicfoundation/ethereumjs-common": "4.0.2",
-				"@nomicfoundation/ethereumjs-rlp": "5.0.2",
-				"debug": "^4.3.3",
-				"ethereum-cryptography": "0.1.3",
-				"ethers": "^5.7.1",
-				"js-sdsl": "^4.1.4"
-			}
-		},
-		"node_modules/@nomicfoundation/ethereumjs-statemanager/node_modules/ethers": {
-			"version": "5.7.2",
-			"resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
-			"integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			],
-			"dependencies": {
-				"@ethersproject/abi": "5.7.0",
-				"@ethersproject/abstract-provider": "5.7.0",
-				"@ethersproject/abstract-signer": "5.7.0",
-				"@ethersproject/address": "5.7.0",
-				"@ethersproject/base64": "5.7.0",
-				"@ethersproject/basex": "5.7.0",
-				"@ethersproject/bignumber": "5.7.0",
-				"@ethersproject/bytes": "5.7.0",
-				"@ethersproject/constants": "5.7.0",
-				"@ethersproject/contracts": "5.7.0",
-				"@ethersproject/hash": "5.7.0",
-				"@ethersproject/hdnode": "5.7.0",
-				"@ethersproject/json-wallets": "5.7.0",
-				"@ethersproject/keccak256": "5.7.0",
-				"@ethersproject/logger": "5.7.0",
-				"@ethersproject/networks": "5.7.1",
-				"@ethersproject/pbkdf2": "5.7.0",
-				"@ethersproject/properties": "5.7.0",
-				"@ethersproject/providers": "5.7.2",
-				"@ethersproject/random": "5.7.0",
-				"@ethersproject/rlp": "5.7.0",
-				"@ethersproject/sha2": "5.7.0",
-				"@ethersproject/signing-key": "5.7.0",
-				"@ethersproject/solidity": "5.7.0",
-				"@ethersproject/strings": "5.7.0",
-				"@ethersproject/transactions": "5.7.0",
-				"@ethersproject/units": "5.7.0",
-				"@ethersproject/wallet": "5.7.0",
-				"@ethersproject/web": "5.7.1",
-				"@ethersproject/wordlists": "5.7.0"
-			}
-		},
-		"node_modules/@nomicfoundation/ethereumjs-trie": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-trie/-/ethereumjs-trie-6.0.2.tgz",
-			"integrity": "sha512-yw8vg9hBeLYk4YNg5MrSJ5H55TLOv2FSWUTROtDtTMMmDGROsAu+0tBjiNGTnKRi400M6cEzoFfa89Fc5k8NTQ==",
-			"dependencies": {
-				"@nomicfoundation/ethereumjs-rlp": "5.0.2",
-				"@nomicfoundation/ethereumjs-util": "9.0.2",
-				"@types/readable-stream": "^2.3.13",
-				"ethereum-cryptography": "0.1.3",
-				"readable-stream": "^3.6.0"
-			},
-			"engines": {
-				"node": ">=14"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@nomicfoundation/ethereumjs-tx": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-tx/-/ethereumjs-tx-5.0.2.tgz",
-			"integrity": "sha512-T+l4/MmTp7VhJeNloMkM+lPU3YMUaXdcXgTGCf8+ZFvV9NYZTRLFekRwlG6/JMmVfIfbrW+dRRJ9A6H5Q/Z64g==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-tx/-/ethereumjs-tx-5.0.4.tgz",
+			"integrity": "sha512-Xjv8wAKJGMrP1f0n2PeyfFCCojHd7iS3s/Ab7qzF1S64kxZ8Z22LCMynArYsVqiFx6rzYy548HNVEyI+AYN/kw==",
 			"dependencies": {
-				"@chainsafe/ssz": "^0.9.2",
-				"@ethersproject/providers": "^5.7.2",
-				"@nomicfoundation/ethereumjs-common": "4.0.2",
-				"@nomicfoundation/ethereumjs-rlp": "5.0.2",
-				"@nomicfoundation/ethereumjs-util": "9.0.2",
+				"@nomicfoundation/ethereumjs-common": "4.0.4",
+				"@nomicfoundation/ethereumjs-rlp": "5.0.4",
+				"@nomicfoundation/ethereumjs-util": "9.0.4",
 				"ethereum-cryptography": "0.1.3"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"c-kzg": "^2.1.2"
+			},
+			"peerDependenciesMeta": {
+				"c-kzg": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@nomicfoundation/ethereumjs-util": {
-			"version": "9.0.2",
-			"resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-util/-/ethereumjs-util-9.0.2.tgz",
-			"integrity": "sha512-4Wu9D3LykbSBWZo8nJCnzVIYGvGCuyiYLIJa9XXNVt1q1jUzHdB+sJvx95VGCpPkCT+IbLecW6yfzy3E1bQrwQ==",
+			"version": "9.0.4",
+			"resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-util/-/ethereumjs-util-9.0.4.tgz",
+			"integrity": "sha512-sLOzjnSrlx9Bb9EFNtHzK/FJFsfg2re6bsGqinFinH1gCqVfz9YYlXiMWwDM4C/L4ywuHFCYwfKTVr/QHQcU0Q==",
 			"dependencies": {
-				"@chainsafe/ssz": "^0.10.0",
-				"@nomicfoundation/ethereumjs-rlp": "5.0.2",
+				"@nomicfoundation/ethereumjs-rlp": "5.0.4",
 				"ethereum-cryptography": "0.1.3"
 			},
 			"engines": {
-				"node": ">=14"
-			}
-		},
-		"node_modules/@nomicfoundation/ethereumjs-util/node_modules/@chainsafe/persistent-merkle-tree": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/@chainsafe/persistent-merkle-tree/-/persistent-merkle-tree-0.5.0.tgz",
-			"integrity": "sha512-l0V1b5clxA3iwQLXP40zYjyZYospQLZXzBVIhhr9kDg/1qHZfzzHw0jj4VPBijfYCArZDlPkRi1wZaV2POKeuw==",
-			"dependencies": {
-				"@chainsafe/as-sha256": "^0.3.1"
-			}
-		},
-		"node_modules/@nomicfoundation/ethereumjs-util/node_modules/@chainsafe/ssz": {
-			"version": "0.10.2",
-			"resolved": "https://registry.npmjs.org/@chainsafe/ssz/-/ssz-0.10.2.tgz",
-			"integrity": "sha512-/NL3Lh8K+0q7A3LsiFq09YXS9fPE+ead2rr7vM2QK8PLzrNsw3uqrif9bpRX5UxgeRjM+vYi+boCM3+GM4ovXg==",
-			"dependencies": {
-				"@chainsafe/as-sha256": "^0.3.1",
-				"@chainsafe/persistent-merkle-tree": "^0.5.0"
-			}
-		},
-		"node_modules/@nomicfoundation/ethereumjs-vm": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-vm/-/ethereumjs-vm-7.0.2.tgz",
-			"integrity": "sha512-Bj3KZT64j54Tcwr7Qm/0jkeZXJMfdcAtRBedou+Hx0dPOSIgqaIr0vvLwP65TpHbak2DmAq+KJbW2KNtIoFwvA==",
-			"dependencies": {
-				"@nomicfoundation/ethereumjs-block": "5.0.2",
-				"@nomicfoundation/ethereumjs-blockchain": "7.0.2",
-				"@nomicfoundation/ethereumjs-common": "4.0.2",
-				"@nomicfoundation/ethereumjs-evm": "2.0.2",
-				"@nomicfoundation/ethereumjs-rlp": "5.0.2",
-				"@nomicfoundation/ethereumjs-statemanager": "2.0.2",
-				"@nomicfoundation/ethereumjs-trie": "6.0.2",
-				"@nomicfoundation/ethereumjs-tx": "5.0.2",
-				"@nomicfoundation/ethereumjs-util": "9.0.2",
-				"debug": "^4.3.3",
-				"ethereum-cryptography": "0.1.3",
-				"mcl-wasm": "^0.7.1",
-				"rustbn.js": "~0.2.0"
+				"node": ">=18"
 			},
-			"engines": {
-				"node": ">=14"
+			"peerDependencies": {
+				"c-kzg": "^2.1.2"
+			},
+			"peerDependenciesMeta": {
+				"c-kzg": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@nomicfoundation/hardhat-chai-matchers": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-chai-matchers/-/hardhat-chai-matchers-2.0.4.tgz",
-			"integrity": "sha512-nvCeGgcN5mBQPP8TeWTrUB63JathBNj6igtpBC43za4CDglK1/UxzbYBl2WiLlNbzSQXACk3+gm/2xEbWanu5g==",
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-chai-matchers/-/hardhat-chai-matchers-2.0.6.tgz",
+			"integrity": "sha512-Te1Uyo9oJcTCF0Jy9dztaLpshmlpjLf2yPtWXlXuLjMt3RRSmJLm/+rKVTW6gfadAEs12U/it6D0ZRnnRGiICQ==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
@@ -1985,9 +1938,9 @@
 			}
 		},
 		"node_modules/@nomicfoundation/hardhat-verify": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-verify/-/hardhat-verify-2.0.4.tgz",
-			"integrity": "sha512-B8ZjhOrmbbRWqJi65jvQblzjsfYktjqj2vmOm+oc2Vu8drZbT2cjeSCRHZKbS7lOtfW78aJZSFvw+zRLCiABJA==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-verify/-/hardhat-verify-2.0.5.tgz",
+			"integrity": "sha512-Tg4zu8RkWpyADSFIgF4FlJIUEI4VkxcvELsmbJn2OokbvH2SnUrqKmw0BBfDrtvP0hhmx8wsnrRKP5DV/oTyTA==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
@@ -2176,9 +2129,9 @@
 			}
 		},
 		"node_modules/@openzeppelin/contracts": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-5.0.1.tgz",
-			"integrity": "sha512-yQJaT5HDp9hYOOp4jTYxMsR02gdFZFXhewX5HW9Jo4fsqSVqqyIO/xTHdWDaKX5a3pv1txmf076Lziz+sO7L1w=="
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-5.0.2.tgz",
+			"integrity": "sha512-ytPc6eLGcHHnapAZ9S+5qsdomhjo6QBHTDRRBFfTxXIpsicMhVPouPgmUPebZZZGX7vt9USA+Z+0M0dSVtSUEA=="
 		},
 		"node_modules/@quais/abi": {
 			"version": "0.1.0",
@@ -2838,9 +2791,9 @@
 			}
 		},
 		"node_modules/@scure/base": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.5.tgz",
-			"integrity": "sha512-Brj9FiG2W1MRQSTB212YVPRrcbjkv48FoZi/u4l/zds/ieRrqsh7aUf6CLwkAq61oKXr/ZlTzlY66gLIj3TFTQ==",
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.6.tgz",
+			"integrity": "sha512-ok9AWwhcgYuGG3Zfhyqg+zwl+Wn5uE+dwC0NV/2qQkx4dABbb/bx96vWu8NSj+BNjjSjno+JRYRjle1jV08k3g==",
 			"funding": {
 				"url": "https://paulmillr.com/funding/"
 			}
@@ -3044,9 +2997,9 @@
 			}
 		},
 		"node_modules/@tsconfig/node10": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
-			"integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+			"integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
 			"devOptional": true,
 			"peer": true
 		},
@@ -3112,9 +3065,9 @@
 			}
 		},
 		"node_modules/@types/chai": {
-			"version": "4.3.11",
-			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.11.tgz",
-			"integrity": "sha512-qQR1dr2rGIHYlJulmr8Ioq3De0Le9E4MJ5AiaeAETJJpndT1uUNHsGFK3L/UIu+rbkQSdj8J/w2bCsBZc/Y5fQ==",
+			"version": "4.3.14",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.14.tgz",
+			"integrity": "sha512-Wj71sXE4Q4AkGdG9Tvq1u/fquNz9EdG4LIJMwVVII7ashjD/8cf8fyIfJAjRr6YcsXnSE8cOGQPq1gqeR8z+3w==",
 			"dev": true,
 			"peer": true
 		},
@@ -3184,9 +3137,9 @@
 			"peer": true
 		},
 		"node_modules/@types/node": {
-			"version": "20.11.17",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.17.tgz",
-			"integrity": "sha512-QmgQZGWu1Yw9TDyAP9ZzpFJKynYNeOvwMJmaxABfieQoVoiVOS6MN1WSpqpRcbeA5+RW82kraAVxCCJg+780Qw==",
+			"version": "20.12.3",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.3.tgz",
+			"integrity": "sha512-sD+ia2ubTeWrOu+YMF+MTAB7E+O7qsMqAbMfW7DG3K1URwhZ5hN1pLlRVGbf4wDFzSfikL05M17EyorS86jShw==",
 			"dependencies": {
 				"undici-types": "~5.26.4"
 			}
@@ -3207,25 +3160,11 @@
 			"peer": true
 		},
 		"node_modules/@types/qs": {
-			"version": "6.9.11",
-			"resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.11.tgz",
-			"integrity": "sha512-oGk0gmhnEJK4Yyk+oI7EfXsLayXatCWPHary1MtcmbAifkobT9cM9yutG/hZKIseOU0MqbIwQ/u2nn/Gb+ltuQ==",
+			"version": "6.9.14",
+			"resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.14.tgz",
+			"integrity": "sha512-5khscbd3SwWMhFqylJBLQ0zIu7c1K6Vz0uBIt915BI3zV0q1nfjRQD3RqSBcPaO6PHEF4ov/t9y89fSiyThlPA==",
 			"dev": true,
 			"peer": true
-		},
-		"node_modules/@types/readable-stream": {
-			"version": "2.3.15",
-			"resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-2.3.15.tgz",
-			"integrity": "sha512-oM5JSKQCcICF1wvGgmecmHldZ48OZamtMxcGGVICOJA8o8cahXC1zEVAif8iwoc5j8etxFaRFnf095+CDsuoFQ==",
-			"dependencies": {
-				"@types/node": "*",
-				"safe-buffer": "~5.1.1"
-			}
-		},
-		"node_modules/@types/readable-stream/node_modules/safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 		},
 		"node_modules/@types/resolve": {
 			"version": "1.20.2",
@@ -3246,23 +3185,6 @@
 			"integrity": "sha512-LEyx4aLEC3x6T0UguF6YILf+ntvmOaWsVfENmIW0E9H09vKlLDGelMjjSm0jkDHALj8A8quZ/HapKNigzwge+Q==",
 			"dev": true,
 			"peer": true
-		},
-		"node_modules/abstract-level": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/abstract-level/-/abstract-level-1.0.4.tgz",
-			"integrity": "sha512-eUP/6pbXBkMbXFdx4IH2fVgvB7M0JvR7/lIL33zcs0IBcwjdzSSl31TOJsaCzmKSSDF9h8QYSOJux4Nd4YJqFg==",
-			"dependencies": {
-				"buffer": "^6.0.3",
-				"catering": "^2.1.0",
-				"is-buffer": "^2.0.5",
-				"level-supports": "^4.0.0",
-				"level-transcoder": "^1.0.1",
-				"module-error": "^1.0.1",
-				"queue-microtask": "^1.2.3"
-			},
-			"engines": {
-				"node": ">=12"
-			}
 		},
 		"node_modules/acorn": {
 			"version": "8.11.3",
@@ -3513,9 +3435,9 @@
 			}
 		},
 		"node_modules/autoprefixer": {
-			"version": "10.4.17",
-			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.17.tgz",
-			"integrity": "sha512-/cpVNRLSfhOtcGflT13P2794gVSgmPgTR+erw5ifnMLZb0UnSlkK4tquLmkd3BhA+nLo5tX8Cu0upUsGKvKbmg==",
+			"version": "10.4.19",
+			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.19.tgz",
+			"integrity": "sha512-BaENR2+zBZ8xXhM4pUaKUxlVdxZ0EZhjvbopwnXmxRUfqDmwSpC2lAi/QXvx7NRdPCo1WKEcEF6mV64si1z4Ew==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -3531,8 +3453,8 @@
 				}
 			],
 			"dependencies": {
-				"browserslist": "^4.22.2",
-				"caniuse-lite": "^1.0.30001578",
+				"browserslist": "^4.23.0",
+				"caniuse-lite": "^1.0.30001599",
 				"fraction.js": "^4.3.7",
 				"normalize-range": "^0.1.2",
 				"picocolors": "^1.0.0",
@@ -3549,13 +3471,13 @@
 			}
 		},
 		"node_modules/axios": {
-			"version": "1.6.7",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
-			"integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
+			"version": "1.6.8",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
+			"integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
-				"follow-redirects": "^1.15.4",
+				"follow-redirects": "^1.15.6",
 				"form-data": "^4.0.0",
 				"proxy-from-env": "^1.1.0"
 			}
@@ -3573,44 +3495,20 @@
 				"safe-buffer": "^5.0.1"
 			}
 		},
-		"node_modules/base64-js": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			]
-		},
 		"node_modules/bech32": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
 			"integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
 		},
-		"node_modules/bigint-crypto-utils": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/bigint-crypto-utils/-/bigint-crypto-utils-3.3.0.tgz",
-			"integrity": "sha512-jOTSb+drvEDxEq6OuUybOAv/xxoh3cuYRUIPyu8sSHQNKM303UQ2R1DAo45o1AkcIXw6fzbaFI1+xGGdaXs2lg==",
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
 		"node_modules/binary-extensions": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-			"integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+			"integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
 			"engines": {
 				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/blakejs": {
@@ -3749,17 +3647,6 @@
 			"resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
 			"integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="
 		},
-		"node_modules/browser-level": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/browser-level/-/browser-level-1.0.1.tgz",
-			"integrity": "sha512-XECYKJ+Dbzw0lbydyQuJzwNXtOpbMSq737qxJN11sIRTErOMShvDpbzTlgju7orJKvx4epULolZAuJGLzCmWRQ==",
-			"dependencies": {
-				"abstract-level": "^1.0.2",
-				"catering": "^2.1.1",
-				"module-error": "^1.0.2",
-				"run-parallel-limit": "^1.1.0"
-			}
-		},
 		"node_modules/browser-stdout": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
@@ -3779,9 +3666,9 @@
 			}
 		},
 		"node_modules/browserslist": {
-			"version": "4.22.3",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.3.tgz",
-			"integrity": "sha512-UAp55yfwNv0klWNapjs/ktHoguxuQNGnOzxYmfnXIS+8AsRDZkSDxg7R1AX3GKzn078SBI5dzwzj/Yx0Or0e3A==",
+			"version": "4.23.0",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz",
+			"integrity": "sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -3797,8 +3684,8 @@
 				}
 			],
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001580",
-				"electron-to-chromium": "^1.4.648",
+				"caniuse-lite": "^1.0.30001587",
+				"electron-to-chromium": "^1.4.668",
 				"node-releases": "^2.0.14",
 				"update-browserslist-db": "^1.0.13"
 			},
@@ -3825,29 +3712,6 @@
 				"bs58": "^4.0.0",
 				"create-hash": "^1.1.0",
 				"safe-buffer": "^5.1.2"
-			}
-		},
-		"node_modules/buffer": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"dependencies": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.2.1"
 			}
 		},
 		"node_modules/buffer-from": {
@@ -3922,9 +3786,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001587",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001587.tgz",
-			"integrity": "sha512-HMFNotUmLXn71BQxg8cijvqxnIAofforZOwGsxyXJ0qugTdspUF4sPSJ2vhgprHCB996tIDzEq1ubumPDV8ULA==",
+			"version": "1.0.30001605",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001605.tgz",
+			"integrity": "sha512-nXwGlFWo34uliI9z3n6Qc0wZaf7zaZWA1CPZ169La5mV3I/gem7bst0vr5XQH5TJXZIMfDeZyOrZnSlVzKxxHQ==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -3940,28 +3804,12 @@
 				}
 			]
 		},
-		"node_modules/case": {
-			"version": "1.6.3",
-			"resolved": "https://registry.npmjs.org/case/-/case-1.6.3.tgz",
-			"integrity": "sha512-mzDSXIPaFwVDvZAHqZ9VlbyF4yyXRuX6IvB06WvPYkqJVO24kX1PPhv9bfpKNFZyxYFmmgo03HUiD8iklmJYRQ==",
-			"engines": {
-				"node": ">= 0.8.0"
-			}
-		},
 		"node_modules/caseless": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
 			"integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
 			"dev": true,
 			"peer": true
-		},
-		"node_modules/catering": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/catering/-/catering-2.1.1.tgz",
-			"integrity": "sha512-K7Qy8O9p76sL3/3m7/zLKbRkyOlSZAgzEaLhyj2mXS8PsCud2Eo4hAb8aLtZqHh0QGqLcb9dlJSu6lHRVENm1w==",
-			"engines": {
-				"node": ">=6"
-			}
 		},
 		"node_modules/cbor": {
 			"version": "8.1.0",
@@ -4082,27 +3930,11 @@
 			}
 		},
 		"node_modules/citty": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/citty/-/citty-0.1.5.tgz",
-			"integrity": "sha512-AS7n5NSc0OQVMV9v6wt3ByujNIrne0/cTjiC2MYqhvao57VNfiuVksTSr2p17nVOhEr2KtqiAkGwHcgMC/qUuQ==",
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
+			"integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
 			"dependencies": {
 				"consola": "^3.2.3"
-			}
-		},
-		"node_modules/classic-level": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/classic-level/-/classic-level-1.4.1.tgz",
-			"integrity": "sha512-qGx/KJl3bvtOHrGau2WklEZuXhS3zme+jf+fsu6Ej7W7IP/C49v7KNlWIsT1jZu0YnfzSIYDGcEWpCa1wKGWXQ==",
-			"hasInstallScript": true,
-			"dependencies": {
-				"abstract-level": "^1.0.2",
-				"catering": "^2.1.0",
-				"module-error": "^1.0.1",
-				"napi-macros": "^2.2.2",
-				"node-gyp-build": "^4.3.0"
-			},
-			"engines": {
-				"node": ">=12"
 			}
 		},
 		"node_modules/clean-stack": {
@@ -4388,17 +4220,6 @@
 			"dev": true,
 			"peer": true
 		},
-		"node_modules/crc-32": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
-			"integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
-			"bin": {
-				"crc32": "bin/crc32.njs"
-			},
-			"engines": {
-				"node": ">=0.8"
-			}
-		},
 		"node_modules/create-hash": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
@@ -4442,9 +4263,9 @@
 			}
 		},
 		"node_modules/css-declaration-sorter": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-7.1.1.tgz",
-			"integrity": "sha512-dZ3bVTEEc1vxr3Bek9vGwfB5Z6ESPULhcRvO472mfjVnj8jRcTnKO8/JTczlvxM10Myb+wBM++1MtdO76eWcaQ==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-7.2.0.tgz",
+			"integrity": "sha512-h70rUM+3PNFuaBDTLe8wF/cdWu+dOZmb7pJt8Z2sedYbAcQVQV/tEchueg3GWxwqS0cxtbxmaHEdkNACqcvsow==",
 			"engines": {
 				"node": "^14 || ^16 || >=18"
 			},
@@ -4502,12 +4323,12 @@
 			}
 		},
 		"node_modules/cssnano": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/cssnano/-/cssnano-6.0.3.tgz",
-			"integrity": "sha512-MRq4CIj8pnyZpcI2qs6wswoYoDD1t0aL28n+41c1Ukcpm56m1h6mCexIHBGjfZfnTqtGSSCP4/fB1ovxgjBOiw==",
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/cssnano/-/cssnano-6.1.2.tgz",
+			"integrity": "sha512-rYk5UeX7VAM/u0lNqewCdasdtPK81CgX8wJFLEIXHbV2oldWRgJAsZrdhRXkV1NJzA2g850KiFm9mMU2HxNxMA==",
 			"dependencies": {
-				"cssnano-preset-default": "^6.0.3",
-				"lilconfig": "^3.0.0"
+				"cssnano-preset-default": "^6.1.2",
+				"lilconfig": "^3.1.1"
 			},
 			"engines": {
 				"node": "^14 || ^16 || >=18.0"
@@ -4521,39 +4342,40 @@
 			}
 		},
 		"node_modules/cssnano-preset-default": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-6.0.3.tgz",
-			"integrity": "sha512-4y3H370aZCkT9Ev8P4SO4bZbt+AExeKhh8wTbms/X7OLDo5E7AYUUy6YPxa/uF5Grf+AJwNcCnxKhZynJ6luBA==",
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-6.1.2.tgz",
+			"integrity": "sha512-1C0C+eNaeN8OcHQa193aRgYexyJtU8XwbdieEjClw+J9d94E41LwT6ivKH0WT+fYwYWB0Zp3I3IZ7tI/BbUbrg==",
 			"dependencies": {
-				"css-declaration-sorter": "^7.1.1",
-				"cssnano-utils": "^4.0.1",
+				"browserslist": "^4.23.0",
+				"css-declaration-sorter": "^7.2.0",
+				"cssnano-utils": "^4.0.2",
 				"postcss-calc": "^9.0.1",
-				"postcss-colormin": "^6.0.2",
-				"postcss-convert-values": "^6.0.2",
-				"postcss-discard-comments": "^6.0.1",
-				"postcss-discard-duplicates": "^6.0.1",
-				"postcss-discard-empty": "^6.0.1",
-				"postcss-discard-overridden": "^6.0.1",
-				"postcss-merge-longhand": "^6.0.2",
-				"postcss-merge-rules": "^6.0.3",
-				"postcss-minify-font-values": "^6.0.1",
-				"postcss-minify-gradients": "^6.0.1",
-				"postcss-minify-params": "^6.0.2",
-				"postcss-minify-selectors": "^6.0.2",
-				"postcss-normalize-charset": "^6.0.1",
-				"postcss-normalize-display-values": "^6.0.1",
-				"postcss-normalize-positions": "^6.0.1",
-				"postcss-normalize-repeat-style": "^6.0.1",
-				"postcss-normalize-string": "^6.0.1",
-				"postcss-normalize-timing-functions": "^6.0.1",
-				"postcss-normalize-unicode": "^6.0.2",
-				"postcss-normalize-url": "^6.0.1",
-				"postcss-normalize-whitespace": "^6.0.1",
-				"postcss-ordered-values": "^6.0.1",
-				"postcss-reduce-initial": "^6.0.2",
-				"postcss-reduce-transforms": "^6.0.1",
-				"postcss-svgo": "^6.0.2",
-				"postcss-unique-selectors": "^6.0.2"
+				"postcss-colormin": "^6.1.0",
+				"postcss-convert-values": "^6.1.0",
+				"postcss-discard-comments": "^6.0.2",
+				"postcss-discard-duplicates": "^6.0.3",
+				"postcss-discard-empty": "^6.0.3",
+				"postcss-discard-overridden": "^6.0.2",
+				"postcss-merge-longhand": "^6.0.5",
+				"postcss-merge-rules": "^6.1.1",
+				"postcss-minify-font-values": "^6.1.0",
+				"postcss-minify-gradients": "^6.0.3",
+				"postcss-minify-params": "^6.1.0",
+				"postcss-minify-selectors": "^6.0.4",
+				"postcss-normalize-charset": "^6.0.2",
+				"postcss-normalize-display-values": "^6.0.2",
+				"postcss-normalize-positions": "^6.0.2",
+				"postcss-normalize-repeat-style": "^6.0.2",
+				"postcss-normalize-string": "^6.0.2",
+				"postcss-normalize-timing-functions": "^6.0.2",
+				"postcss-normalize-unicode": "^6.1.0",
+				"postcss-normalize-url": "^6.0.2",
+				"postcss-normalize-whitespace": "^6.0.2",
+				"postcss-ordered-values": "^6.0.2",
+				"postcss-reduce-initial": "^6.1.0",
+				"postcss-reduce-transforms": "^6.0.2",
+				"postcss-svgo": "^6.0.3",
+				"postcss-unique-selectors": "^6.0.4"
 			},
 			"engines": {
 				"node": "^14 || ^16 || >=18.0"
@@ -4563,9 +4385,9 @@
 			}
 		},
 		"node_modules/cssnano-utils": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-4.0.1.tgz",
-			"integrity": "sha512-6qQuYDqsGoiXssZ3zct6dcMxiqfT6epy7x4R0TQJadd4LWO3sPR6JH6ZByOvVLoZ6EdwPGgd7+DR1EmX3tiXQQ==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-4.0.2.tgz",
+			"integrity": "sha512-ZR1jHg+wZ8o4c3zqf1SIUSTIvm/9mU343FMR6Obe/unskbvpGhZOo1J6d/r8D1pzkRQYuwbcH3hToOuoA2G7oQ==",
 			"engines": {
 				"node": "^14 || ^16 || >=18.0"
 			},
@@ -4602,11 +4424,6 @@
 			"version": "2.0.28",
 			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
 			"integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g=="
-		},
-		"node_modules/csv-parse": {
-			"version": "5.5.5",
-			"resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.5.5.tgz",
-			"integrity": "sha512-erCk7tyU3yLWAhk6wvKxnyPtftuy/6Ak622gOO7BCJ05+TYffnPCJF905wmOQm+BpkX54OdAl8pveJwUdpnCXQ=="
 		},
 		"node_modules/death": {
 			"version": "1.1.0",
@@ -4805,9 +4622,9 @@
 			}
 		},
 		"node_modules/dotenv": {
-			"version": "16.4.4",
-			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.4.tgz",
-			"integrity": "sha512-XvPXc8XAQThSjAbY6cQ/9PcBXmFoWuw1sQ3b8HqUCR6ziGXjkTi//kB9SWa2UwqlgdAIuRqAa/9hVljzPehbYg==",
+			"version": "16.4.5",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+			"integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
 			"engines": {
 				"node": ">=12"
 			},
@@ -4816,9 +4633,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.668",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.668.tgz",
-			"integrity": "sha512-ZOBocMYCehr9W31+GpMclR+KBaDZOoAEabLdhpZ8oU1JFDwIaFY0UDbpXVEUFc0BIP2O2Qn3rkfCjQmMR4T/bQ=="
+			"version": "1.4.724",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.724.tgz",
+			"integrity": "sha512-RTRvkmRkGhNBPPpdrgtDKvmOEYTrPlXDfc0J/Nfq5s29tEahAwhiX4mmhNzj6febWMleulxVYPh7QwCSL/EldA=="
 		},
 		"node_modules/elliptic": {
 			"version": "6.5.4",
@@ -5239,9 +5056,9 @@
 			}
 		},
 		"node_modules/ethers": {
-			"version": "6.11.0",
-			"resolved": "https://registry.npmjs.org/ethers/-/ethers-6.11.0.tgz",
-			"integrity": "sha512-kPHNTnhVWiWU6AVo6CAeTjXEK24SpCXyZvwG9ROFjT0Vlux0EOhWKBAeC+45iDj80QNJTYaT1SDEmeunT0vDNw==",
+			"version": "6.11.1",
+			"resolved": "https://registry.npmjs.org/ethers/-/ethers-6.11.1.tgz",
+			"integrity": "sha512-mxTAE6wqJQAbp5QAe/+o+rXOID7Nw91OZXvgpjDa1r4fAbq2Nu314oEZSbjoRLacuCzs7kUC3clEvkCQowffGg==",
 			"dev": true,
 			"funding": [
 				{
@@ -5399,9 +5216,9 @@
 			}
 		},
 		"node_modules/follow-redirects": {
-			"version": "1.15.5",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
-			"integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
+			"version": "1.15.6",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+			"integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
 			"funding": [
 				{
 					"type": "individual",
@@ -5448,11 +5265,6 @@
 				"type": "patreon",
 				"url": "https://github.com/sponsors/rawify"
 			}
-		},
-		"node_modules/fs": {
-			"version": "0.0.1-security",
-			"resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
-			"integrity": "sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w=="
 		},
 		"node_modules/fs-extra": {
 			"version": "9.1.0",
@@ -5502,11 +5314,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
-		},
-		"node_modules/functional-red-black-tree": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-			"integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g=="
 		},
 		"node_modules/gensync": {
 			"version": "1.0.0-beta.2",
@@ -5715,22 +5522,16 @@
 			}
 		},
 		"node_modules/hardhat": {
-			"version": "2.19.5",
-			"resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.19.5.tgz",
-			"integrity": "sha512-vx8R7zWCYVgM56vA6o0Wqx2bIIptkN4TMs9QwDqZVNGRhMzBfzqUeEYbp+69gxWp1neg2V2nYQUaaUv7aom1kw==",
+			"version": "2.22.2",
+			"resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.22.2.tgz",
+			"integrity": "sha512-0xZ7MdCZ5sJem4MrvpQWLR3R3zGDoHw5lsR+pBFimqwagimIOn3bWuZv69KA+veXClwI1s/zpqgwPwiFrd4Dxw==",
 			"dependencies": {
 				"@ethersproject/abi": "^5.1.2",
 				"@metamask/eth-sig-util": "^4.0.0",
-				"@nomicfoundation/ethereumjs-block": "5.0.2",
-				"@nomicfoundation/ethereumjs-blockchain": "7.0.2",
-				"@nomicfoundation/ethereumjs-common": "4.0.2",
-				"@nomicfoundation/ethereumjs-evm": "2.0.2",
-				"@nomicfoundation/ethereumjs-rlp": "5.0.2",
-				"@nomicfoundation/ethereumjs-statemanager": "2.0.2",
-				"@nomicfoundation/ethereumjs-trie": "6.0.2",
-				"@nomicfoundation/ethereumjs-tx": "5.0.2",
-				"@nomicfoundation/ethereumjs-util": "9.0.2",
-				"@nomicfoundation/ethereumjs-vm": "7.0.2",
+				"@nomicfoundation/edr": "^0.3.1",
+				"@nomicfoundation/ethereumjs-common": "4.0.4",
+				"@nomicfoundation/ethereumjs-tx": "5.0.4",
+				"@nomicfoundation/ethereumjs-util": "9.0.4",
 				"@nomicfoundation/solidity-analyzer": "^0.1.0",
 				"@sentry/node": "^5.18.1",
 				"@types/bn.js": "^5.1.0",
@@ -5924,9 +5725,9 @@
 			}
 		},
 		"node_modules/has-proto": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
-			"integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
+			"integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
 			"dev": true,
 			"peer": true,
 			"engines": {
@@ -5972,9 +5773,9 @@
 			}
 		},
 		"node_modules/hasown": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.1.tgz",
-			"integrity": "sha512-1/th4MHjnwncwXsIW6QMzlvYL9kG5e/CpVvLRZe4XPa8TOUNbCELqmvhDmnkNsAjwaG4+I8gJJL0JBvTTLO9qA==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
 			"dependencies": {
 				"function-bind": "^1.1.2"
 			},
@@ -6083,25 +5884,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/ieee754": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			]
-		},
 		"node_modules/ignore": {
 			"version": "5.3.1",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
@@ -6171,28 +5953,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/is-buffer": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
-			"integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"engines": {
-				"node": ">=4"
 			}
 		},
 		"node_modules/is-builtin-module": {
@@ -6318,15 +6078,6 @@
 				"jiti": "bin/jiti.js"
 			}
 		},
-		"node_modules/js-sdsl": {
-			"version": "4.4.2",
-			"resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.4.2.tgz",
-			"integrity": "sha512-dwXFwByc/ajSV6m5bcKAPwe4yDDF6D614pxmIi5odytzxRlwqF6nwoiCek80Ixc7Cvma5awClxrzFtxCQvcM8w==",
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/js-sdsl"
-			}
-		},
 		"node_modules/js-sha3": {
 			"version": "0.8.0",
 			"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
@@ -6435,43 +6186,6 @@
 				"graceful-fs": "^4.1.9"
 			}
 		},
-		"node_modules/level": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/level/-/level-8.0.1.tgz",
-			"integrity": "sha512-oPBGkheysuw7DmzFQYyFe8NAia5jFLAgEnkgWnK3OXAuJr8qFT+xBQIwokAZPME2bhPFzS8hlYcL16m8UZrtwQ==",
-			"dependencies": {
-				"abstract-level": "^1.0.4",
-				"browser-level": "^1.0.1",
-				"classic-level": "^1.2.0"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/level"
-			}
-		},
-		"node_modules/level-supports": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/level-supports/-/level-supports-4.0.1.tgz",
-			"integrity": "sha512-PbXpve8rKeNcZ9C1mUicC9auIYFyGpkV9/i6g76tLgANwWhtG2v7I4xNBUlkn3lE2/dZF3Pi0ygYGtLc4RXXdA==",
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/level-transcoder": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/level-transcoder/-/level-transcoder-1.0.1.tgz",
-			"integrity": "sha512-t7bFwFtsQeD8cl8NIoQ2iwxA0CL/9IFw7/9gAjOonH0PWTTiRfY7Hq+Ejbsxh86tXobDQ6IOiddjNYIfOBs06w==",
-			"dependencies": {
-				"buffer": "^6.0.3",
-				"module-error": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
 		"node_modules/levn": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -6487,11 +6201,14 @@
 			}
 		},
 		"node_modules/lilconfig": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.0.0.tgz",
-			"integrity": "sha512-K2U4W2Ff5ibV7j7ydLr+zLAkIg5JJ4lPn1Ltsdt+Tz/IjQ8buJ55pZAxoP34lqIiwtF9iAvtLv3JGv7CAyAg+g==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.1.tgz",
+			"integrity": "sha512-O18pf7nyvHTckunPWCV1XUNXU1piu01y2b7ATJ0ppkUkk8ocqVWBrYjJBCwHDjD/ZWcfyrA0P4gKhzWGi5EINQ==",
 			"engines": {
 				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/antonk52"
 			}
 		},
 		"node_modules/locate-path": {
@@ -6652,9 +6369,9 @@
 			}
 		},
 		"node_modules/magic-string": {
-			"version": "0.30.7",
-			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.7.tgz",
-			"integrity": "sha512-8vBuFF/I/+OSLRmdf2wwFCJCz+nSn0m6DPvGH1fS/KiQoSaR+sETbov0eIk9KhEKy8CYqIkIAnbohxT/4H0kuA==",
+			"version": "0.30.8",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.8.tgz",
+			"integrity": "sha512-ISQTe55T2ao7XtlAStud6qwYPZjE4GK1S/BeVPus4jrq6JuOnQ00YKQC581RWhR122W7msZV263KzVeLoqidyQ==",
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.4.15"
 			},
@@ -6676,14 +6393,6 @@
 			"dev": true,
 			"peer": true
 		},
-		"node_modules/mcl-wasm": {
-			"version": "0.7.9",
-			"resolved": "https://registry.npmjs.org/mcl-wasm/-/mcl-wasm-0.7.9.tgz",
-			"integrity": "sha512-iJIUcQWA88IJB/5L15GnJVnSQJmf/YaxxV6zRavv83HILHaJQb6y0iFyDMdDO0gN8X37tdxmAOrH/P8B6RB8sQ==",
-			"engines": {
-				"node": ">=8.9.0"
-			}
-		},
 		"node_modules/md5.js": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -6698,19 +6407,6 @@
 			"version": "2.0.30",
 			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
 			"integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA=="
-		},
-		"node_modules/memory-level": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/memory-level/-/memory-level-1.0.0.tgz",
-			"integrity": "sha512-UXzwewuWeHBz5krr7EvehKcmLFNoXxGcvuYhC41tRnkrTbJohtS7kVn9akmgirtRygg+f7Yjsfi8Uu5SGSQ4Og==",
-			"dependencies": {
-				"abstract-level": "^1.0.0",
-				"functional-red-black-tree": "^1.0.1",
-				"module-error": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			}
 		},
 		"node_modules/memorystream": {
 			"version": "0.3.1",
@@ -6892,9 +6588,9 @@
 			}
 		},
 		"node_modules/mlly": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/mlly/-/mlly-1.5.0.tgz",
-			"integrity": "sha512-NPVQvAY1xr1QoVeG0cy8yUYC7FQcOx6evl/RjT1wL5FvzPnzOysoqB/jmx/DhssT2dYa8nxECLAaFI/+gVLhDQ==",
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/mlly/-/mlly-1.6.1.tgz",
+			"integrity": "sha512-vLgaHvaeunuOXHSmEbZ9izxPx3USsk8KCQ8iC+aTlp5sKRSoZvwhHh5L9VbKSaVC6sJDqbyohIS76E2VmHIPAA==",
 			"dependencies": {
 				"acorn": "^8.11.3",
 				"pathe": "^1.1.2",
@@ -6911,9 +6607,9 @@
 			}
 		},
 		"node_modules/mocha": {
-			"version": "10.3.0",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-10.3.0.tgz",
-			"integrity": "sha512-uF2XJs+7xSLsrmIvn37i/wnc91nw7XjOQB8ccyx5aEgdnohr7n+rEiZP23WkCYHjilR6+EboEnbq/ZQDz4LSbg==",
+			"version": "10.4.0",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-10.4.0.tgz",
+			"integrity": "sha512-eqhGB8JKapEYcC4ytX/xrzKforgEc3j1pGlAXVy3eRwrtAy5/nIfT1SvgGzfN0XZZxeLq0aQWkOUAmqIJiv+bA==",
 			"dependencies": {
 				"ansi-colors": "4.1.1",
 				"browser-stdout": "1.3.1",
@@ -7118,14 +6814,6 @@
 				"url": "https://github.com/chalk/supports-color?sponsor=1"
 			}
 		},
-		"node_modules/module-error": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/module-error/-/module-error-1.0.2.tgz",
-			"integrity": "sha512-0yuvsqSCv8LbaOKhnsQ/T5JhyFlCYLPXK3U2sgV10zoKQwzs/MyfuQUOZQ1V/6OCOJsK/TRgNVrPuPDqtdMFtA==",
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/mri": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
@@ -7155,11 +6843,6 @@
 			"engines": {
 				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
 			}
-		},
-		"node_modules/napi-macros": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.2.2.tgz",
-			"integrity": "sha512-hmEVtAGYzVQpCKdbQea4skABsdXW4RUh5t5mJ2zzqowJS2OyXZTU1KhDVFhx+NlWZ4ap9mqR9TcDO3LTTttd+g=="
 		},
 		"node_modules/neo-async": {
 			"version": "2.6.2",
@@ -7387,15 +7070,6 @@
 			"dev": true,
 			"peer": true
 		},
-		"node_modules/path": {
-			"version": "0.12.7",
-			"resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
-			"integrity": "sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q==",
-			"dependencies": {
-				"process": "^0.11.1",
-				"util": "^0.10.3"
-			}
-		},
 		"node_modules/path-exists": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
@@ -7492,9 +7166,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.4.35",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.35.tgz",
-			"integrity": "sha512-u5U8qYpBCpN13BsiEB0CbR1Hhh4Gc0zLFuedrHJKMctHCHAGrMdG0PRM/KErzAL3CU6/eckEtmHNB3x6e3c0vA==",
+			"version": "8.4.38",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
+			"integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -7512,7 +7186,7 @@
 			"dependencies": {
 				"nanoid": "^3.3.7",
 				"picocolors": "^1.0.0",
-				"source-map-js": "^1.0.2"
+				"source-map-js": "^1.2.0"
 			},
 			"engines": {
 				"node": "^10 || ^12 || >=14"
@@ -7534,13 +7208,13 @@
 			}
 		},
 		"node_modules/postcss-colormin": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-6.0.2.tgz",
-			"integrity": "sha512-TXKOxs9LWcdYo5cgmcSHPkyrLAh86hX1ijmyy6J8SbOhyv6ua053M3ZAM/0j44UsnQNIWdl8gb5L7xX2htKeLw==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-6.1.0.tgz",
+			"integrity": "sha512-x9yX7DOxeMAR+BgGVnNSAxmAj98NX/YxEMNFP+SDCEeNLb2r3i6Hh1ksMsnW8Ub5SLCpbescQqn9YEbE9554Sw==",
 			"dependencies": {
-				"browserslist": "^4.22.2",
+				"browserslist": "^4.23.0",
 				"caniuse-api": "^3.0.0",
-				"colord": "^2.9.1",
+				"colord": "^2.9.3",
 				"postcss-value-parser": "^4.2.0"
 			},
 			"engines": {
@@ -7551,11 +7225,11 @@
 			}
 		},
 		"node_modules/postcss-convert-values": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-6.0.2.tgz",
-			"integrity": "sha512-aeBmaTnGQ+NUSVQT8aY0sKyAD/BaLJenEKZ03YK0JnDE1w1Rr8XShoxdal2V2H26xTJKr3v5haByOhJuyT4UYw==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-6.1.0.tgz",
+			"integrity": "sha512-zx8IwP/ts9WvUM6NkVSkiU902QZL1bwPhaVaLynPtCsOTqp+ZKbNi+s6XJg3rfqpKGA/oc7Oxk5t8pOQJcwl/w==",
 			"dependencies": {
-				"browserslist": "^4.22.2",
+				"browserslist": "^4.23.0",
 				"postcss-value-parser": "^4.2.0"
 			},
 			"engines": {
@@ -7566,9 +7240,9 @@
 			}
 		},
 		"node_modules/postcss-discard-comments": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-6.0.1.tgz",
-			"integrity": "sha512-f1KYNPtqYLUeZGCHQPKzzFtsHaRuECe6jLakf/RjSRqvF5XHLZnM2+fXLhb8Qh/HBFHs3M4cSLb1k3B899RYIg==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-6.0.2.tgz",
+			"integrity": "sha512-65w/uIqhSBBfQmYnG92FO1mWZjJ4GL5b8atm5Yw2UgrwD7HiNiSSNwJor1eCFGzUgYnN/iIknhNRVqjrrpuglw==",
 			"engines": {
 				"node": "^14 || ^16 || >=18.0"
 			},
@@ -7577,9 +7251,9 @@
 			}
 		},
 		"node_modules/postcss-discard-duplicates": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-6.0.1.tgz",
-			"integrity": "sha512-1hvUs76HLYR8zkScbwyJ8oJEugfPV+WchpnA+26fpJ7Smzs51CzGBHC32RS03psuX/2l0l0UKh2StzNxOrKCYg==",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-6.0.3.tgz",
+			"integrity": "sha512-+JA0DCvc5XvFAxwx6f/e68gQu/7Z9ud584VLmcgto28eB8FqSFZwtrLwB5Kcp70eIoWP/HXqz4wpo8rD8gpsTw==",
 			"engines": {
 				"node": "^14 || ^16 || >=18.0"
 			},
@@ -7588,9 +7262,9 @@
 			}
 		},
 		"node_modules/postcss-discard-empty": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-6.0.1.tgz",
-			"integrity": "sha512-yitcmKwmVWtNsrrRqGJ7/C0YRy53i0mjexBDQ9zYxDwTWVBgbU4+C9jIZLmQlTDT9zhml+u0OMFJh8+31krmOg==",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-6.0.3.tgz",
+			"integrity": "sha512-znyno9cHKQsK6PtxL5D19Fj9uwSzC2mB74cpT66fhgOadEUPyXFkbgwm5tvc3bt3NAy8ltE5MrghxovZRVnOjQ==",
 			"engines": {
 				"node": "^14 || ^16 || >=18.0"
 			},
@@ -7599,9 +7273,9 @@
 			}
 		},
 		"node_modules/postcss-discard-overridden": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-6.0.1.tgz",
-			"integrity": "sha512-qs0ehZMMZpSESbRkw1+inkf51kak6OOzNRaoLd/U7Fatp0aN2HQ1rxGOrJvYcRAN9VpX8kUF13R2ofn8OlvFVA==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-6.0.2.tgz",
+			"integrity": "sha512-j87xzI4LUggC5zND7KdjsI25APtyMuynXZSujByMaav2roV6OZX+8AaCUcZSWqckZpjAjRyFDdpqybgjFO0HJQ==",
 			"engines": {
 				"node": "^14 || ^16 || >=18.0"
 			},
@@ -7610,12 +7284,12 @@
 			}
 		},
 		"node_modules/postcss-merge-longhand": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-6.0.2.tgz",
-			"integrity": "sha512-+yfVB7gEM8SrCo9w2lCApKIEzrTKl5yS1F4yGhV3kSim6JzbfLGJyhR1B6X+6vOT0U33Mgx7iv4X9MVWuaSAfw==",
+			"version": "6.0.5",
+			"resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-6.0.5.tgz",
+			"integrity": "sha512-5LOiordeTfi64QhICp07nzzuTDjNSO8g5Ksdibt44d+uvIIAE1oZdRn8y/W5ZtYgRH/lnLDlvi9F8btZcVzu3w==",
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0",
-				"stylehacks": "^6.0.2"
+				"stylehacks": "^6.1.1"
 			},
 			"engines": {
 				"node": "^14 || ^16 || >=18.0"
@@ -7625,14 +7299,14 @@
 			}
 		},
 		"node_modules/postcss-merge-rules": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-6.0.3.tgz",
-			"integrity": "sha512-yfkDqSHGohy8sGYIJwBmIGDv4K4/WrJPX355XrxQb/CSsT4Kc/RxDi6akqn5s9bap85AWgv21ArcUWwWdGNSHA==",
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-6.1.1.tgz",
+			"integrity": "sha512-KOdWF0gju31AQPZiD+2Ar9Qjowz1LTChSjFFbS+e2sFgc4uHOp3ZvVX4sNeTlk0w2O31ecFGgrFzhO0RSWbWwQ==",
 			"dependencies": {
-				"browserslist": "^4.22.2",
+				"browserslist": "^4.23.0",
 				"caniuse-api": "^3.0.0",
-				"cssnano-utils": "^4.0.1",
-				"postcss-selector-parser": "^6.0.15"
+				"cssnano-utils": "^4.0.2",
+				"postcss-selector-parser": "^6.0.16"
 			},
 			"engines": {
 				"node": "^14 || ^16 || >=18.0"
@@ -7642,9 +7316,9 @@
 			}
 		},
 		"node_modules/postcss-minify-font-values": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-6.0.1.tgz",
-			"integrity": "sha512-tIwmF1zUPoN6xOtA/2FgVk1ZKrLcCvE0dpZLtzyyte0j9zUeB8RTbCqrHZGjJlxOvNWKMYtunLrrl7HPOiR46w==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-6.1.0.tgz",
+			"integrity": "sha512-gklfI/n+9rTh8nYaSJXlCo3nOKqMNkxuGpTn/Qm0gstL3ywTr9/WRKznE+oy6fvfolH6dF+QM4nCo8yPLdvGJg==",
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0"
 			},
@@ -7656,12 +7330,12 @@
 			}
 		},
 		"node_modules/postcss-minify-gradients": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-6.0.1.tgz",
-			"integrity": "sha512-M1RJWVjd6IOLPl1hYiOd5HQHgpp6cvJVLrieQYS9y07Yo8itAr6jaekzJphaJFR0tcg4kRewCk3kna9uHBxn/w==",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-6.0.3.tgz",
+			"integrity": "sha512-4KXAHrYlzF0Rr7uc4VrfwDJ2ajrtNEpNEuLxFgwkhFZ56/7gaE4Nr49nLsQDZyUe+ds+kEhf+YAUolJiYXF8+Q==",
 			"dependencies": {
-				"colord": "^2.9.1",
-				"cssnano-utils": "^4.0.1",
+				"colord": "^2.9.3",
+				"cssnano-utils": "^4.0.2",
 				"postcss-value-parser": "^4.2.0"
 			},
 			"engines": {
@@ -7672,12 +7346,12 @@
 			}
 		},
 		"node_modules/postcss-minify-params": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-6.0.2.tgz",
-			"integrity": "sha512-zwQtbrPEBDj+ApELZ6QylLf2/c5zmASoOuA4DzolyVGdV38iR2I5QRMsZcHkcdkZzxpN8RS4cN7LPskOkTwTZw==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-6.1.0.tgz",
+			"integrity": "sha512-bmSKnDtyyE8ujHQK0RQJDIKhQ20Jq1LYiez54WiaOoBtcSuflfK3Nm596LvbtlFcpipMjgClQGyGr7GAs+H1uA==",
 			"dependencies": {
-				"browserslist": "^4.22.2",
-				"cssnano-utils": "^4.0.1",
+				"browserslist": "^4.23.0",
+				"cssnano-utils": "^4.0.2",
 				"postcss-value-parser": "^4.2.0"
 			},
 			"engines": {
@@ -7688,11 +7362,11 @@
 			}
 		},
 		"node_modules/postcss-minify-selectors": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-6.0.2.tgz",
-			"integrity": "sha512-0b+m+w7OAvZejPQdN2GjsXLv5o0jqYHX3aoV0e7RBKPCsB7TYG5KKWBFhGnB/iP3213Ts8c5H4wLPLMm7z28Sg==",
+			"version": "6.0.4",
+			"resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-6.0.4.tgz",
+			"integrity": "sha512-L8dZSwNLgK7pjTto9PzWRoMbnLq5vsZSTu8+j1P/2GB8qdtGQfn+K1uSvFgYvgh83cbyxT5m43ZZhUMTJDSClQ==",
 			"dependencies": {
-				"postcss-selector-parser": "^6.0.15"
+				"postcss-selector-parser": "^6.0.16"
 			},
 			"engines": {
 				"node": "^14 || ^16 || >=18.0"
@@ -7720,9 +7394,9 @@
 			}
 		},
 		"node_modules/postcss-normalize-charset": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-6.0.1.tgz",
-			"integrity": "sha512-aW5LbMNRZ+oDV57PF9K+WI1Z8MPnF+A8qbajg/T8PP126YrGX1f9IQx21GI2OlGz7XFJi/fNi0GTbY948XJtXg==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-6.0.2.tgz",
+			"integrity": "sha512-a8N9czmdnrjPHa3DeFlwqst5eaL5W8jYu3EBbTTkI5FHkfMhFZh1EGbku6jhHhIzTA6tquI2P42NtZ59M/H/kQ==",
 			"engines": {
 				"node": "^14 || ^16 || >=18.0"
 			},
@@ -7731,9 +7405,9 @@
 			}
 		},
 		"node_modules/postcss-normalize-display-values": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-6.0.1.tgz",
-			"integrity": "sha512-mc3vxp2bEuCb4LgCcmG1y6lKJu1Co8T+rKHrcbShJwUmKJiEl761qb/QQCfFwlrvSeET3jksolCR/RZuMURudw==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-6.0.2.tgz",
+			"integrity": "sha512-8H04Mxsb82ON/aAkPeq8kcBbAtI5Q2a64X/mnRRfPXBq7XeogoQvReqxEfc0B4WPq1KimjezNC8flUtC3Qz6jg==",
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0"
 			},
@@ -7745,9 +7419,9 @@
 			}
 		},
 		"node_modules/postcss-normalize-positions": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-6.0.1.tgz",
-			"integrity": "sha512-HRsq8u/0unKNvm0cvwxcOUEcakFXqZ41fv3FOdPn916XFUrympjr+03oaLkuZENz3HE9RrQE9yU0Xv43ThWjQg==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-6.0.2.tgz",
+			"integrity": "sha512-/JFzI441OAB9O7VnLA+RtSNZvQ0NCFZDOtp6QPFo1iIyawyXg0YI3CYM9HBy1WvwCRHnPep/BvI1+dGPKoXx/Q==",
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0"
 			},
@@ -7759,9 +7433,9 @@
 			}
 		},
 		"node_modules/postcss-normalize-repeat-style": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-6.0.1.tgz",
-			"integrity": "sha512-Gbb2nmCy6tTiA7Sh2MBs3fj9W8swonk6lw+dFFeQT68B0Pzwp1kvisJQkdV6rbbMSd9brMlS8I8ts52tAGWmGQ==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-6.0.2.tgz",
+			"integrity": "sha512-YdCgsfHkJ2jEXwR4RR3Tm/iOxSfdRt7jplS6XRh9Js9PyCR/aka/FCb6TuHT2U8gQubbm/mPmF6L7FY9d79VwQ==",
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0"
 			},
@@ -7773,9 +7447,9 @@
 			}
 		},
 		"node_modules/postcss-normalize-string": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-6.0.1.tgz",
-			"integrity": "sha512-5Fhx/+xzALJD9EI26Aq23hXwmv97Zfy2VFrt5PLT8lAhnBIZvmaT5pQk+NuJ/GWj/QWaKSKbnoKDGLbV6qnhXg==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-6.0.2.tgz",
+			"integrity": "sha512-vQZIivlxlfqqMp4L9PZsFE4YUkWniziKjQWUtsxUiVsSSPelQydwS8Wwcuw0+83ZjPWNTl02oxlIvXsmmG+CiQ==",
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0"
 			},
@@ -7787,9 +7461,9 @@
 			}
 		},
 		"node_modules/postcss-normalize-timing-functions": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-6.0.1.tgz",
-			"integrity": "sha512-4zcczzHqmCU7L5dqTB9rzeqPWRMc0K2HoR+Bfl+FSMbqGBUcP5LRfgcH4BdRtLuzVQK1/FHdFoGT3F7rkEnY+g==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-6.0.2.tgz",
+			"integrity": "sha512-a+YrtMox4TBtId/AEwbA03VcJgtyW4dGBizPl7e88cTFULYsprgHWTbfyjSLyHeBcK/Q9JhXkt2ZXiwaVHoMzA==",
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0"
 			},
@@ -7801,11 +7475,11 @@
 			}
 		},
 		"node_modules/postcss-normalize-unicode": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-6.0.2.tgz",
-			"integrity": "sha512-Ff2VdAYCTGyMUwpevTZPZ4w0+mPjbZzLLyoLh/RMpqUqeQKZ+xMm31hkxBavDcGKcxm6ACzGk0nBfZ8LZkStKA==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-6.1.0.tgz",
+			"integrity": "sha512-QVC5TQHsVj33otj8/JD869Ndr5Xcc/+fwRh4HAsFsAeygQQXm+0PySrKbr/8tkDKzW+EVT3QkqZMfFrGiossDg==",
 			"dependencies": {
-				"browserslist": "^4.22.2",
+				"browserslist": "^4.23.0",
 				"postcss-value-parser": "^4.2.0"
 			},
 			"engines": {
@@ -7816,9 +7490,9 @@
 			}
 		},
 		"node_modules/postcss-normalize-url": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-6.0.1.tgz",
-			"integrity": "sha512-jEXL15tXSvbjm0yzUV7FBiEXwhIa9H88JOXDGQzmcWoB4mSjZIsmtto066s2iW9FYuIrIF4k04HA2BKAOpbsaQ==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-6.0.2.tgz",
+			"integrity": "sha512-kVNcWhCeKAzZ8B4pv/DnrU1wNh458zBNp8dh4y5hhxih5RZQ12QWMuQrDgPRw3LRl8mN9vOVfHl7uhvHYMoXsQ==",
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0"
 			},
@@ -7830,9 +7504,9 @@
 			}
 		},
 		"node_modules/postcss-normalize-whitespace": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-6.0.1.tgz",
-			"integrity": "sha512-76i3NpWf6bB8UHlVuLRxG4zW2YykF9CTEcq/9LGAiz2qBuX5cBStadkk0jSkg9a9TCIXbMQz7yzrygKoCW9JuA==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-6.0.2.tgz",
+			"integrity": "sha512-sXZ2Nj1icbJOKmdjXVT9pnyHQKiSAyuNQHSgRCUgThn2388Y9cGVDR+E9J9iAYbSbLHI+UUwLVl1Wzco/zgv0Q==",
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0"
 			},
@@ -7844,11 +7518,11 @@
 			}
 		},
 		"node_modules/postcss-ordered-values": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-6.0.1.tgz",
-			"integrity": "sha512-XXbb1O/MW9HdEhnBxitZpPFbIvDgbo9NK4c/5bOfiKpnIGZDoL2xd7/e6jW5DYLsWxBbs+1nZEnVgnjnlFViaA==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-6.0.2.tgz",
+			"integrity": "sha512-VRZSOB+JU32RsEAQrO94QPkClGPKJEL/Z9PCBImXMhIeK5KAYo6slP/hBYlLgrCjFxyqvn5VC81tycFEDBLG1Q==",
 			"dependencies": {
-				"cssnano-utils": "^4.0.1",
+				"cssnano-utils": "^4.0.2",
 				"postcss-value-parser": "^4.2.0"
 			},
 			"engines": {
@@ -7859,11 +7533,11 @@
 			}
 		},
 		"node_modules/postcss-reduce-initial": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-6.0.2.tgz",
-			"integrity": "sha512-YGKalhNlCLcjcLvjU5nF8FyeCTkCO5UtvJEt0hrPZVCTtRLSOH4z00T1UntQPj4dUmIYZgMj8qK77JbSX95hSw==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-6.1.0.tgz",
+			"integrity": "sha512-RarLgBK/CrL1qZags04oKbVbrrVK2wcxhvta3GCxrZO4zveibqbRPmm2VI8sSgCXwoUHEliRSbOfpR0b/VIoiw==",
 			"dependencies": {
-				"browserslist": "^4.22.2",
+				"browserslist": "^4.23.0",
 				"caniuse-api": "^3.0.0"
 			},
 			"engines": {
@@ -7874,9 +7548,9 @@
 			}
 		},
 		"node_modules/postcss-reduce-transforms": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-6.0.1.tgz",
-			"integrity": "sha512-fUbV81OkUe75JM+VYO1gr/IoA2b/dRiH6HvMwhrIBSUrxq3jNZQZitSnugcTLDi1KkQh1eR/zi+iyxviUNBkcQ==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-6.0.2.tgz",
+			"integrity": "sha512-sB+Ya++3Xj1WaT9+5LOOdirAxP7dJZms3GRcYheSPi1PiTMigsxHAdkrbItHxwYHr4kt1zL7mmcHstgMYT+aiA==",
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0"
 			},
@@ -7888,9 +7562,9 @@
 			}
 		},
 		"node_modules/postcss-selector-parser": {
-			"version": "6.0.15",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.15.tgz",
-			"integrity": "sha512-rEYkQOMUCEMhsKbK66tbEU9QVIxbhN18YiniAwA7XQYTVBqrBy+P2p5JcdqsHgKM2zWylp8d7J6eszocfds5Sw==",
+			"version": "6.0.16",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.16.tgz",
+			"integrity": "sha512-A0RVJrX+IUkVZbW3ClroRWurercFhieevHB38sr2+l9eUClMqome3LmEmnhlNy+5Mr2EYN6B2Kaw9wYdd+VHiw==",
 			"dependencies": {
 				"cssesc": "^3.0.0",
 				"util-deprecate": "^1.0.2"
@@ -7900,9 +7574,9 @@
 			}
 		},
 		"node_modules/postcss-svgo": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-6.0.2.tgz",
-			"integrity": "sha512-IH5R9SjkTkh0kfFOQDImyy1+mTCb+E830+9SV1O+AaDcoHTvfsvt6WwJeo7KwcHbFnevZVCsXhDmjFiGVuwqFQ==",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-6.0.3.tgz",
+			"integrity": "sha512-dlrahRmxP22bX6iKEjOM+c8/1p+81asjKT+V5lrgOH944ryx/OHpclnIbGsKVd3uWOXFLYJwCVf0eEkJGvO96g==",
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0",
 				"svgo": "^3.2.0"
@@ -7915,11 +7589,11 @@
 			}
 		},
 		"node_modules/postcss-unique-selectors": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-6.0.2.tgz",
-			"integrity": "sha512-8IZGQ94nechdG7Y9Sh9FlIY2b4uS8/k8kdKRX040XHsS3B6d1HrJAkXrBSsSu4SuARruSsUjW3nlSw8BHkaAYQ==",
+			"version": "6.0.4",
+			"resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-6.0.4.tgz",
+			"integrity": "sha512-K38OCaIrO8+PzpArzkLKB42dSARtC2tmG6PvD4b1o1Q2E9Os8jzfWFfSy/rixsHwohtsDdFtAWGjFVFUdwYaMg==",
 			"dependencies": {
-				"postcss-selector-parser": "^6.0.15"
+				"postcss-selector-parser": "^6.0.16"
 			},
 			"engines": {
 				"node": "^14 || ^16 || >=18.0"
@@ -7970,14 +7644,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/process": {
-			"version": "0.11.10",
-			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-			"integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
-			"engines": {
-				"node": ">= 0.6.0"
-			}
-		},
 		"node_modules/process-nextick-args": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -8013,13 +7679,13 @@
 			}
 		},
 		"node_modules/qs": {
-			"version": "6.11.2",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.11.2.tgz",
-			"integrity": "sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==",
+			"version": "6.12.0",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.12.0.tgz",
+			"integrity": "sha512-trVZiI6RMOkO476zLGaBIzszOdFPnCCXHPG9kn0yuS1uz6xdVxPfZdB3vUig9pxPFDM9BRAgz/YUIVQ1/vuiUg==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
-				"side-channel": "^1.0.4"
+				"side-channel": "^1.0.6"
 			},
 			"engines": {
 				"node": ">=0.6"
@@ -8335,33 +8001,6 @@
 				"queue-microtask": "^1.2.2"
 			}
 		},
-		"node_modules/run-parallel-limit": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/run-parallel-limit/-/run-parallel-limit-1.1.0.tgz",
-			"integrity": "sha512-jJA7irRNM91jaKc3Hcl1npHsFLOXOoTkPCUL1JEa1R82O2miplXXRaGdjW/KM/98YQWDhJLiSs793CnXfblJUw==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"dependencies": {
-				"queue-microtask": "^1.2.2"
-			}
-		},
-		"node_modules/rustbn.js": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/rustbn.js/-/rustbn.js-0.2.0.tgz",
-			"integrity": "sha512-4VlvkRUuCJvr2J6Y0ImW7NvTCriMi7ErOAqWk1y69vAdoNIzCF3yPmgeNzx+RQTLEDFq5sHfscn1MwHxP9hNfA=="
-		},
 		"node_modules/safe-buffer": {
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -8538,18 +8177,18 @@
 			}
 		},
 		"node_modules/set-function-length": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.1.tgz",
-			"integrity": "sha512-j4t6ccc+VsKwYHso+kElc5neZpjtq9EnRICFZtWyBsLojhmeF/ZBd/elqm22WJh/BziDe/SBiOeAt0m2mfLD0g==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+			"integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
-				"define-data-property": "^1.1.2",
+				"define-data-property": "^1.1.4",
 				"es-errors": "^1.3.0",
 				"function-bind": "^1.1.2",
-				"get-intrinsic": "^1.2.3",
+				"get-intrinsic": "^1.2.4",
 				"gopd": "^1.0.1",
-				"has-property-descriptors": "^1.0.1"
+				"has-property-descriptors": "^1.0.2"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -8610,13 +8249,13 @@
 			}
 		},
 		"node_modules/side-channel": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.5.tgz",
-			"integrity": "sha512-QcgiIWV4WV7qWExbN5llt6frQB/lBven9pqliLXfGPB+K9ZYXxDozp0wLkHS24kWCm+6YXH/f0HhnObZnZOBnQ==",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
+			"integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
-				"call-bind": "^1.0.6",
+				"call-bind": "^1.0.7",
 				"es-errors": "^1.3.0",
 				"get-intrinsic": "^1.2.4",
 				"object-inspect": "^1.13.1"
@@ -8743,9 +8382,9 @@
 			}
 		},
 		"node_modules/solidity-coverage": {
-			"version": "0.8.7",
-			"resolved": "https://registry.npmjs.org/solidity-coverage/-/solidity-coverage-0.8.7.tgz",
-			"integrity": "sha512-RzcPuNsIqVGq5F8rjQZPdI2EVdsRU7w2f1Uk1UY567n9eNcg5LSEQ3Q1WFoy9bi/2AD5SYbYK9SS/Nwh2oYbNw==",
+			"version": "0.8.11",
+			"resolved": "https://registry.npmjs.org/solidity-coverage/-/solidity-coverage-0.8.11.tgz",
+			"integrity": "sha512-yy0Yk+olovBbXn0Me8BWULmmv7A69ZKkP5aTOJGOO8u61Tu2zS989erfjtFlUjDnfWtxRAVkd8BsQD704yLWHw==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
@@ -8869,9 +8508,9 @@
 			}
 		},
 		"node_modules/source-map-js": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-			"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
+			"integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -8990,12 +8629,12 @@
 			}
 		},
 		"node_modules/stylehacks": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-6.0.2.tgz",
-			"integrity": "sha512-00zvJGnCu64EpMjX8b5iCZ3us2Ptyw8+toEkb92VdmkEaRaSGBNKAoK6aWZckhXxmQP8zWiTaFaiMGIU8Ve8sg==",
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-6.1.1.tgz",
+			"integrity": "sha512-gSTTEQ670cJNoaeIp9KX6lZmm8LJ3jPB5yJmX8Zq/wQxOsAFXV3qjWzHas3YYk1qesuVIyYWWUpZ0vSE/dTSGg==",
 			"dependencies": {
-				"browserslist": "^4.22.2",
-				"postcss-selector-parser": "^6.0.15"
+				"browserslist": "^4.23.0",
+				"postcss-selector-parser": "^6.0.16"
 			},
 			"engines": {
 				"node": "^14 || ^16 || >=18.0"
@@ -9084,9 +8723,9 @@
 			}
 		},
 		"node_modules/table": {
-			"version": "6.8.1",
-			"resolved": "https://registry.npmjs.org/table/-/table-6.8.1.tgz",
-			"integrity": "sha512-Y4X9zqrCftUhMeH2EptSSERdVKt/nEdijTOacGD/97EKjhQ/Qs8RTlEGABSJNNN8lac9kheH+af7yAkEWlgneA==",
+			"version": "6.8.2",
+			"resolved": "https://registry.npmjs.org/table/-/table-6.8.2.tgz",
+			"integrity": "sha512-w2sfv80nrAh2VCbqR5AK27wswXhqcck2AhfnNW76beQXskGZ1V12GwS//yYVa3d3fcvAip2OUnbDAjW2k3v9fA==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
@@ -9533,9 +9172,9 @@
 			"peer": true
 		},
 		"node_modules/typescript": {
-			"version": "5.3.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-			"integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+			"version": "5.4.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.3.tgz",
+			"integrity": "sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg==",
 			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
@@ -9556,9 +9195,9 @@
 			}
 		},
 		"node_modules/ufo": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/ufo/-/ufo-1.4.0.tgz",
-			"integrity": "sha512-Hhy+BhRBleFjpJ2vchUNN40qgkh0366FWJGqVLYBHev0vpHTrXSA0ryT+74UiW6KWsldNurQMKGqCm1M2zBciQ=="
+			"version": "1.5.3",
+			"resolved": "https://registry.npmjs.org/ufo/-/ufo-1.5.3.tgz",
+			"integrity": "sha512-Y7HYmWaFwPUmkoQCUIAYpKqkOf+SbVj/2fJJZ4RJMCfZp0rTGwRbzQD+HghfnhKOjL9E01okqz+ncJskGYfBNw=="
 		},
 		"node_modules/uglify-js": {
 			"version": "3.17.4",
@@ -9657,9 +9296,9 @@
 			}
 		},
 		"node_modules/undici": {
-			"version": "5.28.3",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-5.28.3.tgz",
-			"integrity": "sha512-3ItfzbrhDlINjaP0duwnNsKpDQk3acHI3gVJ1z4fmwMK31k5G9OVIAMLSIaP6w4FaGkaAkN6zaQO9LUvZ1t7VA==",
+			"version": "5.28.4",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
+			"integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
 			"dependencies": {
 				"@fastify/busboy": "^2.0.0"
 			},
@@ -9751,23 +9390,10 @@
 			"dev": true,
 			"peer": true
 		},
-		"node_modules/util": {
-			"version": "0.10.4",
-			"resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
-			"integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
-			"dependencies": {
-				"inherits": "2.0.3"
-			}
-		},
 		"node_modules/util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
-		},
-		"node_modules/util/node_modules/inherits": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-			"integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw=="
 		},
 		"node_modules/uuid": {
 			"version": "8.3.2",

--- a/Solidity/package-lock.json
+++ b/Solidity/package-lock.json
@@ -6,8 +6,11 @@
 		"": {
 			"dependencies": {
 				"@openzeppelin/contracts": "^5.0.1",
+				"csv-parse": "^5.5.5",
 				"dotenv": "^16.4.3",
+				"fs": "^0.0.1-security",
 				"hardhat": "^2.19.5",
+				"path": "^0.12.7",
 				"quais": "^0.1.17",
 				"quais-polling": "^1.0.4"
 			},
@@ -4600,6 +4603,11 @@
 			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
 			"integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g=="
 		},
+		"node_modules/csv-parse": {
+			"version": "5.5.5",
+			"resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.5.5.tgz",
+			"integrity": "sha512-erCk7tyU3yLWAhk6wvKxnyPtftuy/6Ak622gOO7BCJ05+TYffnPCJF905wmOQm+BpkX54OdAl8pveJwUdpnCXQ=="
+		},
 		"node_modules/death": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/death/-/death-1.1.0.tgz",
@@ -5440,6 +5448,11 @@
 				"type": "patreon",
 				"url": "https://github.com/sponsors/rawify"
 			}
+		},
+		"node_modules/fs": {
+			"version": "0.0.1-security",
+			"resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
+			"integrity": "sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w=="
 		},
 		"node_modules/fs-extra": {
 			"version": "9.1.0",
@@ -7374,6 +7387,15 @@
 			"dev": true,
 			"peer": true
 		},
+		"node_modules/path": {
+			"version": "0.12.7",
+			"resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
+			"integrity": "sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q==",
+			"dependencies": {
+				"process": "^0.11.1",
+				"util": "^0.10.3"
+			}
+		},
 		"node_modules/path-exists": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
@@ -7946,6 +7968,14 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/process": {
+			"version": "0.11.10",
+			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+			"integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+			"engines": {
+				"node": ">= 0.6.0"
 			}
 		},
 		"node_modules/process-nextick-args": {
@@ -9721,10 +9751,23 @@
 			"dev": true,
 			"peer": true
 		},
+		"node_modules/util": {
+			"version": "0.10.4",
+			"resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+			"integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+			"dependencies": {
+				"inherits": "2.0.3"
+			}
+		},
 		"node_modules/util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+		},
+		"node_modules/util/node_modules/inherits": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+			"integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw=="
 		},
 		"node_modules/uuid": {
 			"version": "8.3.2",

--- a/Solidity/package.json
+++ b/Solidity/package.json
@@ -1,8 +1,11 @@
 {
 	"dependencies": {
 		"@openzeppelin/contracts": "^5.0.1",
+		"csv-parse": "^5.5.5",
 		"dotenv": "^16.4.3",
+		"fs": "^0.0.1-security",
 		"hardhat": "^2.19.5",
+		"path": "^0.12.7",
 		"quais": "^0.1.17",
 		"quais-polling": "^1.0.4"
 	},

--- a/Solidity/package.json
+++ b/Solidity/package.json
@@ -1,11 +1,8 @@
 {
 	"dependencies": {
 		"@openzeppelin/contracts": "^5.0.1",
-		"csv-parse": "^5.5.5",
 		"dotenv": "^16.4.3",
-		"fs": "^0.0.1-security",
 		"hardhat": "^2.19.5",
-		"path": "^0.12.7",
 		"quais": "^0.1.17",
 		"quais-polling": "^1.0.4"
 	},

--- a/Solidity/scripts/deployERC20.js
+++ b/Solidity/scripts/deployERC20.js
@@ -7,7 +7,7 @@ require('dotenv').config()
 tokenArgs = {
   name: process.env.ERC20_NAME,
   symbol: process.env.ERC20_SYMBOL,
-  initialSupply: process.env.ERC20_INITIALSUPPLY,
+  initialSupply: quais.utils.parseUnits(process.env.ERC20_INITIALSUPPLY),
 }
 
 async function deployERC20() {
@@ -25,7 +25,7 @@ async function deployERC20() {
   // Wait for contract to be deployed (using quais-polling)
   const deployReceipt = await pollFor(provider, 'getTransactionReceipt', [erc20.deployTransaction.hash], 1.5, 1)
   console.log('3 -- Transaction mined. ERC20 deployed to:', deployReceipt.contractAddress)
-  console.log('  -- Gas used:', deployReceipt.cumulativeGasUsed.toString())
+  console.log('Gas used:', deployReceipt.cumulativeGasUsed.toString())
 }
 
 deployERC20()

--- a/Solidity/scripts/deployERC721.js
+++ b/Solidity/scripts/deployERC721.js
@@ -8,6 +8,7 @@ tokenArgs = {
   name: process.env.ERC721_NAME, // Name of collection
   symbol: process.env.ERC721_SYMBOL, // Collection symbol
   baseURI: process.env.ERC721_BASE_URI, // Base URI for token metadata (make sure to keep the slash at the end)
+  maxTokens: process.env.ERC721_MAX_TOKENS, // Maximum number of tokens that can be minted
 }
 
 async function deployERC721() {
@@ -17,7 +18,7 @@ async function deployERC721() {
   const ERC721 = new quais.ContractFactory(ERC721Json.abi, ERC721Json.bytecode, wallet)
 
   // Broadcast deploy transaction
-  const erc721 = await ERC721.deploy(tokenArgs.name, tokenArgs.symbol, tokenArgs.baseURI, {
+  const erc721 = await ERC721.deploy(tokenArgs.name, tokenArgs.symbol, tokenArgs.baseURI, tokenArgs.maxTokens, {
     gasLimit: 5000000,
   })
   console.log('1 -- Deploy transaction broadcasted: ' + erc721.deployTransaction.hash + '\n2 -- Waiting for transaction to be mined.')


### PR DESCRIPTION
- Remove supply calculations in contract, move them to deployScript
- Update ERC721 contract to use URI storage extension, add logic that adds ".json" to the end of TokenURI
  - Made this as many users don't format their IPFS metadata without ".json" extension
- Start ERC721 token index from 1, not 0 to be better compliant with metadata standards
- Add max tokens to ERC721 constructor args for variable supply