### PR TITLE
Bump quais version + add evmVersion to compiler

### DIFF
--- a/Solidity/hardhat.config.js
+++ b/Solidity/hardhat.config.js
@@ -23,6 +23,7 @@ module.exports = {
         enabled: true,
         runs: 1000,
       },
+      evmVersion: 'london',
     },
   },
 

--- a/Solidity/package-lock.json
+++ b/Solidity/package-lock.json
@@ -8,7 +8,7 @@
 				"@openzeppelin/contracts": "^5.0.0",
 				"dotenv": "^16.4.5",
 				"hardhat": "^2.19.5",
-				"quais": "^1.0.0-alpha.21"
+				"quais": "^1.0.0-alpha.22"
 			},
 			"devDependencies": {
 				"@nomicfoundation/hardhat-toolbox": "^5.0.0"
@@ -5368,9 +5368,9 @@
 			}
 		},
 		"node_modules/quais": {
-			"version": "1.0.0-alpha.21",
-			"resolved": "https://registry.npmjs.org/quais/-/quais-1.0.0-alpha.21.tgz",
-			"integrity": "sha512-1A2pkYC78AyONZgo+zBb562YQs2FaCmhlvYUSzX7mz0PgQedUGGInILp/abxo1EdH1FFCnL1yzUG1gpyK3yAWw==",
+			"version": "1.0.0-alpha.22",
+			"resolved": "https://registry.npmjs.org/quais/-/quais-1.0.0-alpha.22.tgz",
+			"integrity": "sha512-XbTSljklzDUTImOPvuzLBEeN8Di6FITUD5JzStV2O0LJ4gr2nRsf0tlaDnFRD4P5iGuZ5V9SzhDKNyCaZu/odA==",
 			"dependencies": {
 				"@bitcoinerlab/secp256k1": "^1.1.1",
 				"@brandonblack/musig": "^0.0.1-alpha.1",

--- a/Solidity/package.json
+++ b/Solidity/package.json
@@ -3,7 +3,7 @@
 		"@openzeppelin/contracts": "^5.0.0",
 		"dotenv": "^16.4.5",
 		"hardhat": "^2.19.5",
-		"quais": "^1.0.0-alpha.21"
+		"quais": "^1.0.0-alpha.22"
 	},
 	"devDependencies": {
 		"@nomicfoundation/hardhat-toolbox": "^5.0.0"

--- a/SolidityX/hardhat.config.js
+++ b/SolidityX/hardhat.config.js
@@ -18,15 +18,15 @@ module.exports = {
   },
 
   solidity: {
-    version: '0.8.0',
+    version: '0.8.20',
     settings: {
       optimizer: {
         enabled: true,
         runs: 1000,
       },
+      evmVersion: 'london',
     },
   },
-
   // etherscan: {
   //   apiKey: {
   //     cyprus1: 'abc',

--- a/SolidityX/package-lock.json
+++ b/SolidityX/package-lock.json
@@ -8,7 +8,7 @@
         "dotenv": "^16.4.5",
         "hardhat": "^2.19.5",
         "quai-hardhat-plugin": "^1.0.3",
-        "quais": "^1.0.0-alpha.21"
+        "quais": "^1.0.0-alpha.22"
       },
       "devDependencies": {
         "@nomicfoundation/hardhat-toolbox": "^5.0.0"
@@ -7187,9 +7187,9 @@
       }
     },
     "node_modules/quais": {
-      "version": "1.0.0-alpha.21",
-      "resolved": "https://registry.npmjs.org/quais/-/quais-1.0.0-alpha.21.tgz",
-      "integrity": "sha512-1A2pkYC78AyONZgo+zBb562YQs2FaCmhlvYUSzX7mz0PgQedUGGInILp/abxo1EdH1FFCnL1yzUG1gpyK3yAWw==",
+      "version": "1.0.0-alpha.22",
+      "resolved": "https://registry.npmjs.org/quais/-/quais-1.0.0-alpha.22.tgz",
+      "integrity": "sha512-XbTSljklzDUTImOPvuzLBEeN8Di6FITUD5JzStV2O0LJ4gr2nRsf0tlaDnFRD4P5iGuZ5V9SzhDKNyCaZu/odA==",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "^1.1.1",
         "@brandonblack/musig": "^0.0.1-alpha.1",

--- a/SolidityX/package.json
+++ b/SolidityX/package.json
@@ -3,7 +3,7 @@
     "dotenv": "^16.4.5",
     "hardhat": "^2.19.5",
     "quai-hardhat-plugin": "^1.0.3",
-    "quais": "^1.0.0-alpha.21"
+    "quais": "^1.0.0-alpha.22"
   },
   "devDependencies": {
     "@nomicfoundation/hardhat-toolbox": "^5.0.0"


### PR DESCRIPTION
- Upgrade quais to latest version, should fix many big development bugs
- Add `evmVersion: 'london'` to solidity compiler spec for better network compatibility